### PR TITLE
Improve store price filter and pagination

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,10 +13,15 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
+.np-price__slider{ position:relative; height:30px; --min:0%; --max:100%; }
+.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; height:6px; border-radius:999px; background:#d9dfe3; transform:translateY(-50%); }
+.np-price__slider::after{ content:""; position:absolute; left:var(--min); right:calc(100% - var(--max)); top:50%; height:6px; border-radius:999px; background:#0f5b62; transform:translateY(-50%); }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; margin:0; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; cursor:pointer; }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; cursor:pointer; }
+.np-price__slider input::-webkit-slider-runnable-track{ height:6px; background:transparent; }
+.np-price__slider input::-moz-range-track{ height:6px; background:transparent; }
+.np-price__slider input:focus-visible{ outline:none; }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,10 +13,15 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
+.np-price__slider{ position:relative; height:30px; --min:0%; --max:100%; }
+.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; height:6px; border-radius:999px; background:#d9dfe3; transform:translateY(-50%); }
+.np-price__slider::after{ content:""; position:absolute; left:var(--min); right:calc(100% - var(--max)); top:50%; height:6px; border-radius:999px; background:#0f5b62; transform:translateY(-50%); }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; margin:0; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; cursor:pointer; }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; cursor:pointer; }
+.np-price__slider input::-webkit-slider-runnable-track{ height:6px; background:transparent; }
+.np-price__slider input::-moz-range-track{ height:6px; background:transparent; }
+.np-price__slider input:focus-visible{ outline:none; }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
@@ -31,6 +36,12 @@
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
 .np-pagination{ margin:20px 0; text-align:center; }
+.np-pagination__nav{ display:inline-flex; align-items:center; gap:6px; background:#fff; border:1px solid var(--np-border); border-radius:999px; padding:6px 10px; }
+.np-pagination__button{ border:none; background:transparent; color:var(--np-text); font-weight:600; padding:6px 10px; border-radius:999px; cursor:pointer; transition:background .2s ease, color .2s ease; }
+.np-pagination__button:hover, .np-pagination__button:focus-visible{ background:rgba(15,91,98,.1); color:#0f5b62; outline:none; }
+.np-pagination__button.is-active{ background:#0f5b62; color:#fff; cursor:default; }
+.np-pagination__button[aria-disabled="true"], .np-pagination__button:disabled{ opacity:.5; cursor:not-allowed; }
+.np-pagination__ellipsis{ padding:0 4px; color:#7a858d; font-weight:700; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,74 +1,264 @@
 jQuery(function($){
-  function clamp(v,a,b){ v=parseFloat(v||0); return Math.min(Math.max(v,a), b); }
-  function syncPriceUI($root){
-    const $wrap = $root.find('.np-price__slider'); if (!$wrap.length) return {};
-    const min = parseFloat($wrap.data('min')), max = parseFloat($wrap.data('max'));
-    const $min = $wrap.find('.np-range-min'), $max = $wrap.find('.np-range-max');
-    let vmin = clamp($min.val(), min, max), vmax = clamp($max.val(), min, max);
-    if (vmin>vmax){ const t=vmin; vmin=vmax; vmax=t; $min.val(vmin); $max.val(vmax); }
-    $root.find('.np-price-min').text(vmin); $root.find('.np-price-max').text(vmax);
-    return {min:vmin, max:vmax};
+  const priceDecimals = parseInt(NorpumpsStore.price_decimals || 0, 10);
+  const thousandSeparator = NorpumpsStore.thousand_separator || ',';
+  const decimalSeparator = NorpumpsStore.decimal_separator || '.';
+  const currencySymbol = NorpumpsStore.currency_symbol || '';
+  const currencyPosition = NorpumpsStore.currency_position || 'left';
+
+  function clamp(v, a, b){
+    v = parseFloat(v || 0);
+    if (!isFinite(v)) v = 0;
+    return Math.min(Math.max(v, a), b);
   }
+
+  function formatNumber(value){
+    if (value == null || isNaN(value)) return '0';
+    const negative = value < 0;
+    const absolute = Math.abs(value);
+    let fixed = absolute.toFixed(priceDecimals);
+    let [intPart, decPart] = fixed.split('.');
+    intPart = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator);
+    let output = negative ? '-' : '';
+    output += intPart;
+    if (priceDecimals > 0){
+      decPart = decPart || '';
+      if (decPart.length > priceDecimals){
+        decPart = decPart.slice(0, priceDecimals);
+      }
+      while (decPart.length < priceDecimals){
+        decPart += '0';
+      }
+      output += decimalSeparator + decPart;
+    }
+    return output;
+  }
+
+  function formatPrice(value){
+    const formatted = formatNumber(value);
+    switch(currencyPosition){
+      case 'right':
+        return formatted + currencySymbol;
+      case 'left_space':
+        return currencySymbol + ' ' + formatted;
+      case 'right_space':
+        return formatted + ' ' + currencySymbol;
+      case 'left':
+      default:
+        return currencySymbol + formatted;
+    }
+  }
+
+  function setCurrentPage($root, page){
+    page = parseInt(page || 1, 10);
+    if (!page || page < 1) page = 1;
+    $root.data('page', page);
+  }
+
+  function getCurrentPage($root){
+    const page = parseInt($root.data('page'), 10);
+    return page && page > 0 ? page : 1;
+  }
+
+  function getPerPage($root){
+    const per = parseInt($root.data('per-page'), 10);
+    return per && per > 0 ? per : 12;
+  }
+
+  function syncPriceUI($root){
+    const $wrap = $root.find('.np-price__slider');
+    if (!$wrap.length) return {};
+
+    const min = parseFloat($wrap.data('min')) || 0;
+    const max = parseFloat($wrap.data('max')) || 0;
+    const range = max - min;
+    const $min = $wrap.find('.np-range-min');
+    const $max = $wrap.find('.np-range-max');
+
+    let vmin = clamp($min.val(), min, max);
+    let vmax = clamp($max.val(), min, max);
+    if (vmin > vmax){ const swap = vmin; vmin = vmax; vmax = swap; }
+
+    const factor = Math.pow(10, priceDecimals);
+    if (isFinite(factor) && factor > 0){
+      vmin = Math.round(vmin * factor) / factor;
+      vmax = Math.round(vmax * factor) / factor;
+    }
+
+    $min.val(vmin);
+    $max.val(vmax);
+
+    const pctMin = range > 0 ? ((vmin - min) / range) * 100 : 0;
+    const pctMax = range > 0 ? ((vmax - min) / range) * 100 : 100;
+    const el = $wrap.get(0);
+    if (el){
+      el.style.setProperty('--min', pctMin + '%');
+      el.style.setProperty('--max', pctMax + '%');
+    }
+
+    $root.find('.np-price-min').text(formatPrice(vmin));
+    $root.find('.np-price-max').text(formatPrice(vmax));
+
+    return { min: vmin, max: vmax };
+  }
+
   function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
+    const data = {
+      action: 'norpumps_store_query',
+      nonce: NorpumpsStore.nonce,
+      per_page: getPerPage($root),
+      page: getCurrentPage($root)
+    };
+
     data.orderby = $root.find('.np-orderby select').val();
-    const q = $root.find('.np-search').val(); if (q) data.s = q;
-    const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
+    const q = $root.find('.np-search').val();
+    if (q) data.s = q;
+
+    const pr = syncPriceUI($root);
+    if (pr.min != null) data.min_price = pr.min;
+    if (pr.max != null) data.max_price = pr.max;
+
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
-      const vals = $(this).find('input:checked').map(function(){return this.value;}).get();
+      const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
       const allOn = $(this).closest('.np-filter__body').find('.np-all-toggle').is(':checked');
-      if (vals.length && !allOn) data['cat_'+group] = vals.join(',');
+      if (vals.length && !allOn){
+        data['cat_' + group] = vals.join(',');
+      }
     });
+
     return data;
   }
+
   function toQuery(obj){
     const p = new URLSearchParams();
-    Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
+    Object.keys(obj).forEach(function(key){
+      if (['action', 'nonce'].includes(key)) return;
+      const value = obj[key];
+      if (value === '' || value == null) return;
+      if (key === 'page' && parseInt(value, 10) <= 1) return;
+      if (key === 'per_page' && parseInt(value, 10) === 12) return;
+      p.set(key, value);
+    });
     return p.toString();
   }
-  function load($root){
+
+  function load($root, opts){
+    opts = opts || {};
+    if (opts.resetPage) setCurrentPage($root, 1);
+    if (opts.page) setCurrentPage($root, opts.page);
+
     const data = buildQuery($root);
     const qs = toQuery(data);
-    history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
-    $.post(NorpumpsStore.ajax_url, data, function(resp){
-      if (!resp || !resp.success) return;
-      $root.find('.js-np-grid').html(resp.data.html);
-    });
+    history.replaceState(null, '', qs ? (location.pathname + '?' + qs) : location.pathname);
+
+    $root.addClass('is-loading');
+    $.post(NorpumpsStore.ajax_url, data)
+      .always(function(){
+        $root.removeClass('is-loading');
+      })
+      .done(function(resp){
+        if (!resp || !resp.success) return;
+        $root.find('.js-np-grid').html(resp.data.html || '');
+        $root.find('.js-np-pagination').html(resp.data.pagination || '');
+      });
   }
+
+  function schedulePriceLoad($root){
+    const timerId = $root.data('npPriceTimer');
+    if (timerId) window.clearTimeout(timerId);
+    const newTimer = window.setTimeout(function(){
+      $root.removeData('npPriceTimer');
+      load($root, { resetPage: true });
+    }, 250);
+    $root.data('npPriceTimer', newTimer);
+  }
+
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
-      load($root);
+      load($root, { resetPage: true });
     });
+
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
       const $body = $(this).closest('.np-filter__body');
       if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
-      const anyChecked = $body.find('.np-checklist input:checked').length>0;
+      const anyChecked = $body.find('.np-checklist input:checked').length > 0;
       if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
-      load($root);
+      load($root, { resetPage: true });
     });
   }
+
   $('.norpumps-store').each(function(){
     const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
-    bindAllToggle($root);
-    const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
-    if (pmin!=null) $root.find('.np-range-min').val(pmin);
-    if (pmax!=null) $root.find('.np-range-max').val(pmax);
-    syncPriceUI($root);
-    $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
-      const group = $(this).data('group'); const key = 'cat_'+group;
-      const vals = (url.searchParams.get(key)||'').split(',').filter(Boolean);
-      if (vals.length){
-        const $body = $(this).closest('.np-filter__body'); $body.find('.np-all-toggle').prop('checked', false);
-        $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });
+    const perPageAttr = parseInt($root.data('per-page'), 10);
+    $root.data('per-page', perPageAttr && perPageAttr > 0 ? perPageAttr : 12);
+    setCurrentPage($root, 1);
+
+    $root.on('change', '.np-orderby select', function(){
+      load($root, { resetPage: true });
+    });
+
+    $root.on('input', '.np-price__slider input[type=range]', function(){
+      syncPriceUI($root);
+      setCurrentPage($root, 1);
+      schedulePriceLoad($root);
+    });
+
+    $root.on('change', '.np-price__slider input[type=range]', function(){
+      const timerId = $root.data('npPriceTimer');
+      if (timerId) window.clearTimeout(timerId);
+      $root.removeData('npPriceTimer');
+      syncPriceUI($root);
+      load($root, { resetPage: true });
+    });
+
+    $root.on('keyup', '.np-search', function(e){
+      if (e.keyCode === 13){
+        load($root, { resetPage: true });
       }
     });
+
+    $root.on('submit', '.np-search-form', function(e){
+      e.preventDefault();
+      load($root, { resetPage: true });
+    });
+
+    $root.on('click', '.np-pagination__button', function(e){
+      e.preventDefault();
+      const $btn = $(this);
+      if ($btn.is('.is-active') || $btn.is('[aria-disabled="true"]')) return;
+      const page = parseInt($btn.data('page'), 10);
+      if (!page || page < 1) return;
+      load($root, { page: page });
+    });
+
+    bindAllToggle($root);
+
+    const url = new URL(window.location.href);
+    const pmin = url.searchParams.get('min_price');
+    const pmax = url.searchParams.get('max_price');
+    const page = parseInt(url.searchParams.get('page'), 10);
+
+    if (pmin != null) $root.find('.np-range-min').val(pmin);
+    if (pmax != null) $root.find('.np-range-max').val(pmax);
+    if (page && page > 1) setCurrentPage($root, page);
+
+    syncPriceUI($root);
+
+    $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
+      const group = $(this).data('group');
+      const key = 'cat_' + group;
+      const vals = (url.searchParams.get(key) || '').split(',').filter(Boolean);
+      if (vals.length){
+        const $body = $(this).closest('.np-filter__body');
+        $body.find('.np-all-toggle').prop('checked', false);
+        $(this).find('input').each(function(){
+          if (vals.includes(this.value)) this.checked = true;
+        });
+      }
+    });
+
     load($root);
   });
 });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,11 +1,20 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$price_min = isset($atts['price_min']) ? floatval($atts['price_min']) : 0;
-$price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
+$price_decimals = isset($price_decimals) ? intval($price_decimals) : wc_get_price_decimals();
+$price_step = isset($price_step) ? $price_step : pow(10, max(0, $price_decimals) * -1);
+$price_min = isset($price_min) ? floatval($price_min) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
+$price_max = isset($price_max) ? floatval($price_max) : (isset($atts['price_max']) ? floatval($atts['price_max']) : $price_min);
+if ($price_max < $price_min) $price_max = $price_min;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
+$per_page = isset($per_page) ? intval($per_page) : 12;
+$price_min_attr = wc_format_decimal($price_min, $price_decimals);
+$price_max_attr = wc_format_decimal($price_max, $price_decimals);
+$price_step_attr = wc_format_decimal($price_step, $price_decimals);
+$price_min_label = wp_strip_all_tags( wc_price($price_min) );
+$price_max_label = wp_strip_all_tags( wc_price($price_max) );
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -29,14 +38,14 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
         <div class="np-filter__body">
           <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($price_min); ?>" data-max="<?php echo esc_attr($price_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
+            <div class="np-price__slider" data-min="<?php echo esc_attr($price_min_attr); ?>" data-max="<?php echo esc_attr($price_max_attr); ?>">
+              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="<?php echo esc_attr($price_step_attr); ?>" value="<?php echo esc_attr($price_min_attr); ?>">
+              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="<?php echo esc_attr($price_step_attr); ?>" value="<?php echo esc_attr($price_max_attr); ?>">
             </div>
             <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($price_min); ?></span>
+              <span class="np-price-min"><?php echo esc_html($price_min_label); ?></span>
               <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($price_max); ?></span>
+              <span class="np-price-max"><?php echo esc_html($price_max_label); ?></span>
             </div>
           </div>
         </div>

--- a/norpumps.php
+++ b/norpumps.php
@@ -57,6 +57,11 @@ class NorPumps_App {
         wp_localize_script('norpumps-store','NorpumpsStore',[
             'ajax_url'=>admin_url('admin-ajax.php'),
             'nonce'=>wp_create_nonce('norpumps_store'),
+            'currency_symbol'=>get_woocommerce_currency_symbol(),
+            'currency_position'=>get_option('woocommerce_currency_pos','left'),
+            'decimal_separator'=>wc_get_price_decimal_separator(),
+            'thousand_separator'=>wc_get_price_thousand_separator(),
+            'price_decimals'=>wc_get_price_decimals(),
         ]);
     }
     public function admin_assets($hook){


### PR DESCRIPTION
## Summary
- restyle the store price slider for better contrast and currency-aware labels
- auto-trigger filtering on price changes using real product min/max bounds
- add paginated AJAX responses with styled navigation controls

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php
- php -l norpumps.php

------
https://chatgpt.com/codex/tasks/task_e_68dab1871d8483308502c97c61e9d9d8