### PR TITLE
Revamp store price filter slider and pagination

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,11 +13,25 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
+.np-price__slider{ position:relative; height:36px; }
+.np-price__track{ position:absolute; top:50%; left:0; right:0; height:6px; background:#d6dde2; border-radius:999px; transform:translateY(-50%); }
+.np-price__range{ position:absolute; top:0; bottom:0; background:#0f5b62; border-radius:999px; }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:36px; margin:0; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:18px; height:18px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px rgba(15,91,98,.35); cursor:pointer; }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px rgba(15,91,98,.35); cursor:pointer; }
+.np-price__slider input::-webkit-slider-runnable-track{ -webkit-appearance:none; height:6px; background:transparent; }
+.np-price__slider input::-moz-range-track{ height:6px; background:transparent; }
+.np-price__slider input:focus{ outline:none; }
+.np-price__slider input:focus-visible::-webkit-slider-thumb{ box-shadow:0 0 0 4px rgba(15,91,98,.25); }
+.np-price__slider input:focus-visible::-moz-range-thumb{ box-shadow:0 0 0 4px rgba(15,91,98,.25); }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
+.norpumps-store.is-loading .js-np-grid{ opacity:.45; pointer-events:none; }
+.np-pagination__inner{ display:inline-flex; align-items:center; gap:6px; flex-wrap:wrap; justify-content:center; }
+.np-page-btn{ border:1px solid var(--np-border); background:#fff; color:var(--np-text); padding:6px 10px; border-radius:8px; min-width:36px; font-weight:600; cursor:pointer; transition:all .15s ease; }
+.np-page-btn:hover:not([disabled]){ background:rgba(15,91,98,.08); border-color:#0f5b62; color:#0f5b62; }
+.np-page-btn.is-active{ background:#0f5b62; border-color:#0f5b62; color:#fff; cursor:default; }
+.np-page-btn[disabled]{ opacity:.45; cursor:not-allowed; }
+.np-page-ellipsis{ padding:0 4px; color:#6a7a83; font-weight:600; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,69 +1,175 @@
 jQuery(function($){
-  function clamp(v,a,b){ v=parseFloat(v||0); return Math.min(Math.max(v,a), b); }
+  const locale = (typeof NorpumpsStore !== 'undefined' && NorpumpsStore.locale) ? NorpumpsStore.locale.replace('_','-') : undefined;
+  const numberFormatter = new Intl.NumberFormat(locale || undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 });
+  function clamp(value, min, max){
+    let v = parseFloat(value);
+    let lo = parseFloat(min);
+    let hi = parseFloat(max);
+    if (isNaN(v)) v = !isNaN(lo) ? lo : (!isNaN(hi) ? hi : 0);
+    if (isNaN(lo)) lo = v;
+    if (isNaN(hi)) hi = v;
+    if (lo > hi){ const tmp = lo; lo = hi; hi = tmp; }
+    if (v < lo) v = lo;
+    if (v > hi) v = hi;
+    return v;
+  }
+  function formatPrice(value){
+    const num = parseFloat(value);
+    if (isNaN(num)) return value;
+    const formatted = numberFormatter.format(num);
+    if (typeof NorpumpsStore === 'undefined') return formatted;
+    const symbol = NorpumpsStore.currency_symbol || '';
+    const position = NorpumpsStore.currency_position || 'left';
+    switch (position){
+      case 'left': return symbol + formatted;
+      case 'left_space': return symbol + ' ' + formatted;
+      case 'right': return formatted + symbol;
+      case 'right_space': return formatted + ' ' + symbol;
+      default: return symbol + formatted;
+    }
+  }
   function syncPriceUI($root){
     const $wrap = $root.find('.np-price__slider'); if (!$wrap.length) return {};
-    const min = parseFloat($wrap.data('min')), max = parseFloat($wrap.data('max'));
-    const $min = $wrap.find('.np-range-min'), $max = $wrap.find('.np-range-max');
-    let vmin = clamp($min.val(), min, max), vmax = clamp($max.val(), min, max);
-    if (vmin>vmax){ const t=vmin; vmin=vmax; vmax=t; $min.val(vmin); $max.val(vmax); }
-    $root.find('.np-price-min').text(vmin); $root.find('.np-price-max').text(vmax);
-    return {min:vmin, max:vmax};
+    const min = parseFloat($wrap.data('min'));
+    const max = parseFloat($wrap.data('max'));
+    const rangeTotal = (!isNaN(max) && !isNaN(min)) ? (max - min) : 0;
+    const $min = $wrap.find('.np-range-min');
+    const $max = $wrap.find('.np-range-max');
+    let vmin = clamp($min.val(), min, max);
+    let vmax = clamp($max.val(), min, max);
+    if (vmin > vmax){ const t = vmin; vmin = vmax; vmax = t; $min.val(vmin); $max.val(vmax); }
+    const base = rangeTotal > 0 ? rangeTotal : 1;
+    const rawMin = rangeTotal > 0 ? ((vmin - min) / base) * 100 : 0;
+    const rawMax = rangeTotal > 0 ? ((vmax - min) / base) * 100 : 100;
+    const start = Math.max(0, Math.min(100, rawMin));
+    const end = Math.max(start, Math.max(0, Math.min(100, rawMax)));
+    const width = rangeTotal > 0 ? (end - start) : 100;
+    $wrap.find('.np-price__range').css({ left: start + '%', width: width + '%' });
+    $root.find('.np-price-min').text(formatPrice(vmin));
+    $root.find('.np-price-max').text(formatPrice(vmax));
+    return { min: vmin, max: vmax };
   }
   function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
+    const perPage = parseInt($root.data('per-page'), 10) || 12;
+    const page = parseInt($root.data('page'), 10) || 1;
+    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page: perPage, page: page };
     data.orderby = $root.find('.np-orderby select').val();
     const q = $root.find('.np-search').val(); if (q) data.s = q;
-    const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
+    const pr = syncPriceUI($root); if (pr.min != null) data.min_price = pr.min; if (pr.max != null) data.max_price = pr.max;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
-      const vals = $(this).find('input:checked').map(function(){return this.value;}).get();
+      const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
       const allOn = $(this).closest('.np-filter__body').find('.np-all-toggle').is(':checked');
-      if (vals.length && !allOn) data['cat_'+group] = vals.join(',');
+      if (vals.length && !allOn) data['cat_' + group] = vals.join(',');
     });
     return data;
   }
   function toQuery(obj){
     const p = new URLSearchParams();
-    Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
+    Object.keys(obj).forEach(function(k){
+      if (k === 'action' || k === 'nonce') return;
+      if (k === 'page' && (!obj[k] || obj[k] === 1)) return;
+      if (obj[k] !== '' && obj[k] != null) p.set(k, obj[k]);
+    });
     return p.toString();
   }
-  function load($root){
+  function renderPagination($root, meta){
+    const $container = $root.find('.js-np-pagination');
+    if (!meta || !meta.pages || meta.pages <= 1){ $container.empty(); return; }
+    const current = parseInt(meta.page, 10) || 1;
+    const total = parseInt(meta.pages, 10) || 1;
+    const maxButtons = 5;
+    let start = Math.max(1, current - Math.floor(maxButtons / 2));
+    let end = start + maxButtons - 1;
+    if (end > total){ end = total; start = Math.max(1, end - maxButtons + 1); }
+    const buttons = [];
+    const prevPage = current > 1 ? current - 1 : 1;
+    buttons.push('<button type="button" class="np-page-btn np-page-prev" data-page="' + prevPage + '" ' + (current <= 1 ? 'disabled' : '') + '>‹</button>');
+    if (start > 1){
+      buttons.push('<button type="button" class="np-page-btn" data-page="1">1</button>');
+      if (start > 2) buttons.push('<span class="np-page-ellipsis">…</span>');
+    }
+    for (let i = start; i <= end; i++){
+      buttons.push('<button type="button" class="np-page-btn' + (i === current ? ' is-active' : '') + '" data-page="' + i + '" ' + (i === current ? 'disabled' : '') + '>' + i + '</button>');
+    }
+    if (end < total){
+      if (end < total - 1) buttons.push('<span class="np-page-ellipsis">…</span>');
+      buttons.push('<button type="button" class="np-page-btn" data-page="' + total + '">' + total + '</button>');
+    }
+    const nextPage = current < total ? current + 1 : total;
+    buttons.push('<button type="button" class="np-page-btn np-page-next" data-page="' + nextPage + '" ' + (current >= total ? 'disabled' : '') + '>›</button>');
+    $container.html('<div class="np-pagination__inner">' + buttons.join('') + '</div>');
+  }
+  function load($root, page){
+    if (page){ $root.data('page', page); }
     const data = buildQuery($root);
     const qs = toQuery(data);
-    history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
+    history.replaceState(null, '', qs ? (location.pathname + '?' + qs) : location.pathname);
+    $root.addClass('is-loading');
     $.post(NorpumpsStore.ajax_url, data, function(resp){
+      $root.removeClass('is-loading');
       if (!resp || !resp.success) return;
+      $root.data('page', data.page);
       $root.find('.js-np-grid').html(resp.data.html);
+      renderPagination($root, resp.data.pagination);
     });
   }
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
+      $root.data('page', 1);
       load($root);
     });
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
       const $body = $(this).closest('.np-filter__body');
       if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
-      const anyChecked = $body.find('.np-checklist input:checked').length>0;
+      const anyChecked = $body.find('.np-checklist input:checked').length > 0;
       if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
+      $root.data('page', 1);
       load($root);
     });
   }
   $('.norpumps-store').each(function(){
     const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
+    const initialPerPage = parseInt($root.data('per-page'), 10) || 12;
+    $root.data('per-page', initialPerPage);
+    $root.data('page', parseInt($root.data('page'), 10) || 1);
+    let priceDebounce = null;
+    $root.on('change', '.np-orderby select', function(){ $root.data('page', 1); load($root); });
+    $root.on('input', '.np-price__slider input[type=range]', function(){
+      syncPriceUI($root);
+      if (priceDebounce) clearTimeout(priceDebounce);
+      priceDebounce = setTimeout(function(){ $root.data('page', 1); load($root); }, 300);
+    });
+    $root.on('change', '.np-price__slider input[type=range]', function(){
+      if (priceDebounce) clearTimeout(priceDebounce);
+      $root.data('page', 1);
+      load($root);
+    });
+    $root.on('keyup', '.np-search', function(e){ if (e.keyCode === 13){ $root.data('page', 1); load($root); } });
+    $root.on('click', '.js-np-pagination button.np-page-btn', function(e){
+      e.preventDefault();
+      const target = parseInt($(this).data('page'), 10);
+      if (!target || $(this).is('[disabled]')) return;
+      load($root, target);
+    });
     bindAllToggle($root);
     const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
-    if (pmin!=null) $root.find('.np-range-min').val(pmin);
-    if (pmax!=null) $root.find('.np-range-max').val(pmax);
+    const pmin = url.searchParams.get('min_price');
+    const pmax = url.searchParams.get('max_price');
+    if (pmin != null) $root.find('.np-range-min').val(pmin);
+    if (pmax != null) $root.find('.np-range-max').val(pmax);
+    const urlPage = parseInt(url.searchParams.get('page'), 10); if (urlPage > 1) $root.data('page', urlPage);
+    const searchValue = url.searchParams.get('s'); if (searchValue != null) $root.find('.np-search').val(searchValue);
+    const orderValue = url.searchParams.get('orderby'); if (orderValue){
+      const $select = $root.find('.np-orderby select');
+      if ($select.find('option[value="' + orderValue + '"]').length){ $select.val(orderValue); }
+    }
     syncPriceUI($root);
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
-      const group = $(this).data('group'); const key = 'cat_'+group;
-      const vals = (url.searchParams.get(key)||'').split(',').filter(Boolean);
+      const group = $(this).data('group'); const key = 'cat_' + group;
+      const vals = (url.searchParams.get(key) || '').split(',').filter(Boolean);
       if (vals.length){
         const $body = $(this).closest('.np-filter__body'); $body.find('.np-all-toggle').prop('checked', false);
         $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -5,7 +5,7 @@ $price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -30,13 +30,16 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__body">
           <div class="np-price">
             <div class="np-price__slider" data-min="<?php echo esc_attr($price_min); ?>" data-max="<?php echo esc_attr($price_max); ?>">
+              <div class="np-price__track">
+                <div class="np-price__range"></div>
+              </div>
               <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
               <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
             </div>
             <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($price_min); ?></span>
+              <span class="np-price-min"><?php echo wp_kses_post(wc_price($price_min)); ?></span>
               <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($price_max); ?></span>
+              <span class="np-price-max"><?php echo wp_kses_post(wc_price($price_max)); ?></span>
             </div>
           </div>
         </div>

--- a/norpumps.php
+++ b/norpumps.php
@@ -57,6 +57,9 @@ class NorPumps_App {
         wp_localize_script('norpumps-store','NorpumpsStore',[
             'ajax_url'=>admin_url('admin-ajax.php'),
             'nonce'=>wp_create_nonce('norpumps_store'),
+            'currency_symbol'=>get_woocommerce_currency_symbol(),
+            'currency_position'=>get_option('woocommerce_currency_pos','left'),
+            'locale'=>get_locale(),
         ]);
     }
     public function admin_assets($hook){


### PR DESCRIPTION
## Summary
- restyle the price slider with a visible track and highlight plus add loading and pagination button styles
- refresh the store frontend script to show currency-formatted ranges, debounce slider input, and render AJAX-driven pagination tied to filters
- drive slider bounds from real product prices, expose per-page data, and return pagination metadata from the AJAX handler while localizing currency info

## Testing
- php -l modules/store/module.php
- php -l norpumps.php

------
https://chatgpt.com/codex/tasks/task_e_68dab1871d8483308502c97c61e9d9d8