### PR TITLE
Improve store price filtering UX and add pagination

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,10 +13,16 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
+.np-price__slider{ position:relative; height:30px; --np-track-bg:#d7dde5; --np-track-active:#0f5b62; --min:0%; --max:100%; }
+.np-price__slider::before,
+.np-price__slider::after{ content:""; position:absolute; left:12px; right:12px; height:4px; top:50%; transform:translateY(-50%); border-radius:999px; pointer-events:none; }
+.np-price__slider::before{ background:var(--np-track-bg); z-index:1; }
+.np-price__slider::after{ background:linear-gradient(to right, transparent 0, transparent var(--min), var(--np-track-active) var(--min), var(--np-track-active) var(--max), transparent var(--max), transparent 100%); z-index:2; transition:background .15s ease; }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; margin:0; z-index:3; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; cursor:pointer; }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; cursor:pointer; }
+.np-price__slider input::-webkit-slider-runnable-track{ background:transparent; height:4px; }
+.np-price__slider input::-moz-range-track{ background:transparent; height:4px; }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,11 +13,24 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
+.np-price__slider{ position:relative; height:30px; --np-track-bg:#d7dde5; --np-track-active:#0f5b62; --min:0%; --max:100%; }
+.np-price__slider::before,
+.np-price__slider::after{ content:""; position:absolute; left:12px; right:12px; height:4px; top:50%; transform:translateY(-50%); border-radius:999px; pointer-events:none; }
+.np-price__slider::before{ background:var(--np-track-bg); z-index:1; }
+.np-price__slider::after{ background:linear-gradient(to right, transparent 0, transparent var(--min), var(--np-track-active) var(--min), var(--np-track-active) var(--max), transparent var(--max), transparent 100%); z-index:2; transition:background .15s ease; }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; margin:0; z-index:3; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; cursor:pointer; }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; cursor:pointer; }
+.np-price__slider input::-webkit-slider-runnable-track{ background:transparent; height:4px; }
+.np-price__slider input::-moz-range-track{ background:transparent; height:4px; }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
+.np-pagination{ margin:20px 0; text-align:center; }
+.np-pagination__nav{ display:inline-flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.np-pagination__nav button{ border:1px solid #d0d5dd; background:#fff; color:#0f5b62; font-size:13px; line-height:1; padding:7px 11px; border-radius:6px; cursor:pointer; transition:all .15s ease; }
+.np-pagination__nav button:hover{ background:#0f5b62; color:#fff; border-color:#0f5b62; }
+.np-pagination__nav button.is-active{ background:#0f5b62; color:#fff; border-color:#0f5b62; cursor:default; }
+.np-pagination__nav button.is-disabled{ opacity:.45; cursor:not-allowed; background:#f5f7fa; color:#6b7280; border-color:#d0d5dd; }
+.np-pagination__ellipsis{ color:#6b7280; font-size:13px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }
@@ -30,7 +43,6 @@
 .np-card__title{ font-size:16px; margin:6px 0 8px; min-height:44px; }
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
-.np-pagination{ margin:20px 0; text-align:center; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,19 +1,55 @@
 jQuery(function($){
   function clamp(v,a,b){ v=parseFloat(v||0); return Math.min(Math.max(v,a), b); }
+  function debounce(fn, wait){
+    let timeout;
+    function debounced(){
+      const ctx=this, args=arguments;
+      clearTimeout(timeout);
+      timeout = setTimeout(function(){ fn.apply(ctx,args); }, wait);
+    }
+    debounced.cancel = function(){ clearTimeout(timeout); };
+    return debounced;
+  }
+  function formatPrice(value){
+    const num = parseFloat(value);
+    if (!isFinite(num)) return '0';
+    const rounded = Math.round(num * 100) / 100;
+    const hasDecimals = Math.abs(rounded % 1) > 0;
+    return rounded.toLocaleString(undefined, {
+      minimumFractionDigits: hasDecimals ? 2 : 0,
+      maximumFractionDigits: hasDecimals ? 2 : 0
+    });
+  }
   function syncPriceUI($root){
     const $wrap = $root.find('.np-price__slider'); if (!$wrap.length) return {};
-    const min = parseFloat($wrap.data('min')), max = parseFloat($wrap.data('max'));
+    const min = parseFloat($wrap.data('min')) || 0;
+    const max = parseFloat($wrap.data('max')) || 0;
     const $min = $wrap.find('.np-range-min'), $max = $wrap.find('.np-range-max');
     let vmin = clamp($min.val(), min, max), vmax = clamp($max.val(), min, max);
-    if (vmin>vmax){ const t=vmin; vmin=vmax; vmax=t; $min.val(vmin); $max.val(vmax); }
-    $root.find('.np-price-min').text(vmin); $root.find('.np-price-max').text(vmax);
+    if (vmin>vmax){ const t=vmin; vmin=vmax; vmax=t; }
+    $min.val(vmin); $max.val(vmax);
+    const span = max>min ? (max-min) : 0;
+    let pctMin = 0, pctMax = 100;
+    if (span>0){
+      pctMin = ((vmin-min)/span)*100;
+      pctMax = ((vmax-min)/span)*100;
+    }
+    pctMin = Math.min(Math.max(pctMin,0),100);
+    pctMax = Math.min(Math.max(pctMax,0),100);
+    $wrap.css('--min', pctMin+'%').css('--max', pctMax+'%');
+    $root.find('.np-price-min').text(formatPrice(vmin));
+    $root.find('.np-price-max').text(formatPrice(vmax));
     return {min:vmin, max:vmax};
   }
   function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
+    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12 };
     data.orderby = $root.find('.np-orderby select').val();
     const q = $root.find('.np-search').val(); if (q) data.s = q;
-    const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
+    const pr = syncPriceUI($root);
+    if (pr.min!=null) data.min_price = pr.min;
+    if (pr.max!=null) data.max_price = pr.max;
+    const page = parseInt($root.data('page'),10) || 1;
+    data.page = page;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       const vals = $(this).find('input:checked').map(function(){return this.value;}).get();
@@ -24,22 +60,79 @@ jQuery(function($){
   }
   function toQuery(obj){
     const p = new URLSearchParams();
-    Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
+    Object.keys(obj).forEach(function(k){
+      if (['action','nonce'].includes(k)) return;
+      if (obj[k]==='' || obj[k]==null) return;
+      if (k==='page' && parseInt(obj[k],10)<=1) return;
+      if (k==='per_page' && parseInt(obj[k],10)===12) return;
+      p.set(k,obj[k]);
+    });
     return p.toString();
+  }
+  function renderPagination($root, meta){
+    const $container = $root.find('.js-np-pagination');
+    if (!meta || !meta.total || meta.total<=1){ $container.empty(); return; }
+    const current = Math.max(1, parseInt(meta.current,10) || 1);
+    const total = Math.max(1, parseInt(meta.total,10) || 1);
+    let html = '<nav class="np-pagination__nav" aria-label="Paginación de productos">';
+    function addButton(page, label, opts){
+      opts = opts || {};
+      const disabled = !!opts.disabled;
+      const active = !!opts.active;
+      const classes = ['np-page'];
+      if (disabled) classes.push('is-disabled');
+      if (active) classes.push('is-active');
+      const attrs = ['type="button"', 'class="'+classes.join(' ')+'"'];
+      if (opts.aria){ attrs.push('aria-label="'+opts.aria+'"'); }
+      if (!disabled) attrs.push('data-page="'+page+'"');
+      html += '<button '+attrs.join(' ') + (disabled ? ' disabled' : '')+'>'+label+'</button>';
+    }
+    function addEllipsis(){ html += '<span class="np-pagination__ellipsis" aria-hidden="true">…</span>'; }
+    addButton(Math.max(1,current-1), '‹', { disabled: current<=1, aria:'Página anterior' });
+    const windowSize = 2;
+    let start = Math.max(1, current-windowSize);
+    let end = Math.min(total, current+windowSize);
+    if (current<=windowSize+1){ end = Math.min(total, 1+windowSize*2); start = 1; }
+    if (current>=total-windowSize){ start = Math.max(1, total-windowSize*2); end = total; }
+    if (start>1){ addButton(1,'1',{active: current===1}); if (start>2) addEllipsis(); }
+    for (let page=start; page<=end; page++){
+      addButton(page, page, { active: page===current });
+    }
+    if (end<total){ if (end<total-1) addEllipsis(); addButton(total, total, { active: current===total }); }
+    addButton(Math.min(total,current+1), '›', { disabled: current>=total, aria:'Página siguiente' });
+    html += '</nav>';
+    $container.html(html);
   }
   function load($root){
     const data = buildQuery($root);
-    const qs = toQuery(data);
-    history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
-    $.post(NorpumpsStore.ajax_url, data, function(resp){
+    const payload = $.extend({}, data);
+    $.post(NorpumpsStore.ajax_url, payload, function(resp){
       if (!resp || !resp.success) return;
-      $root.find('.js-np-grid').html(resp.data.html);
+      if (resp.data && typeof resp.data.html!=='undefined'){
+        $root.find('.js-np-grid').html(resp.data.html);
+      }
+      if (resp.data && resp.data.pagination){
+        renderPagination($root, resp.data.pagination);
+        if (resp.data.pagination.current){
+          const newPage = parseInt(resp.data.pagination.current,10) || 1;
+          $root.data('page', newPage);
+          data.page = newPage;
+        }
+      } else {
+        $root.find('.js-np-pagination').empty();
+        $root.data('page',1);
+        data.page = 1;
+      }
+      const qs = toQuery(data);
+      const url = qs ? (location.pathname+'?'+qs) : location.pathname;
+      history.replaceState(null,'', url);
     });
   }
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
+      $root.data('page',1);
       load($root);
     });
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
@@ -47,23 +140,37 @@ jQuery(function($){
       if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
       const anyChecked = $body.find('.np-checklist input:checked').length>0;
       if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
+      $root.data('page',1);
       load($root);
     });
   }
   $('.norpumps-store').each(function(){
     const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
+    const debouncedPriceLoad = debounce(function(){ load($root); }, 250);
+    $root.on('change', '.np-orderby select', function(){ $root.data('page',1); load($root); });
+    $root.on('input', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); $root.data('page',1); debouncedPriceLoad(); });
+    $root.on('change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); debouncedPriceLoad.cancel(); $root.data('page',1); load($root); });
+    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13){ $root.data('page',1); load($root); } });
+    $root.on('click', '.np-page', function(){
+      const $btn = $(this);
+      if ($btn.hasClass('is-disabled') || $btn.hasClass('is-active') || this.disabled) return;
+      const page = parseInt($btn.data('page'),10);
+      if (!page || page===($root.data('page')||1)) return;
+      $root.data('page', page);
+      load($root);
+    });
     bindAllToggle($root);
-    const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
+    const urlObj = new URL(window.location.href);
+    const pmin = urlObj.searchParams.get('min_price');
+    const pmax = urlObj.searchParams.get('max_price');
+    const page = parseInt(urlObj.searchParams.get('page'),10);
+    if (!isNaN(page) && page>1) $root.data('page', page); else $root.data('page',1);
     if (pmin!=null) $root.find('.np-range-min').val(pmin);
     if (pmax!=null) $root.find('.np-range-max').val(pmax);
     syncPriceUI($root);
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group'); const key = 'cat_'+group;
-      const vals = (url.searchParams.get(key)||'').split(',').filter(Boolean);
+      const vals = (urlObj.searchParams.get(key)||'').split(',').filter(Boolean);
       if (vals.length){
         const $body = $(this).closest('.np-filter__body'); $body.find('.np-all-toggle').prop('checked', false);
         $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,7 +1,13 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$price_min = isset($atts['price_min']) ? floatval($atts['price_min']) : 0;
-$price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
+$price_slider_min = isset($price_slider_min) ? floatval($price_slider_min) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
+$price_slider_max = isset($price_slider_max) ? floatval($price_slider_max) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
+if ($price_slider_max < $price_slider_min) { $price_slider_max = $price_slider_min; }
+$price_selected_min = isset($price_current_min) ? floatval($price_current_min) : $price_slider_min;
+$price_selected_max = isset($price_current_max) ? floatval($price_current_max) : $price_slider_max;
+$price_selected_min = max($price_slider_min, min($price_slider_max, $price_selected_min));
+$price_selected_max = max($price_slider_min, min($price_slider_max, $price_selected_max));
+if ($price_selected_min > $price_selected_max) { $price_selected_min = $price_slider_min; $price_selected_max = $price_slider_max; }
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
@@ -29,14 +35,14 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
         <div class="np-filter__body">
           <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($price_min); ?>" data-max="<?php echo esc_attr($price_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
+            <div class="np-price__slider" data-min="<?php echo esc_attr($price_slider_min); ?>" data-max="<?php echo esc_attr($price_slider_max); ?>">
+              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_slider_min); ?>" max="<?php echo esc_attr($price_slider_max); ?>" value="<?php echo esc_attr($price_selected_min); ?>">
+              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_slider_min); ?>" max="<?php echo esc_attr($price_slider_max); ?>" value="<?php echo esc_attr($price_selected_max); ?>">
             </div>
             <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($price_min); ?></span>
+              <span class="np-price-min"><?php echo esc_html($price_selected_min); ?></span>
               <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($price_max); ?></span>
+              <span class="np-price-max"><?php echo esc_html($price_selected_max); ?></span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle the store price slider with a visible track and formatted labels for better contrast
- trigger AJAX filtering on price changes with debounce and add responsive pagination controls that sync with the URL
- derive slider bounds from real product prices so the selectable range always matches the catalog

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68dab1871d8483308502c97c61e9d9d8