### PR TITLE
Add WooCommerce product frontend tabs module

### DIFF
--- a/modules/product-frontend/assets/css/product-frontend.css
+++ b/modules/product-frontend/assets/css/product-frontend.css
@@ -1,0 +1,39 @@
+.woocommerce div.product .np-tab {
+    padding: 1.5em 0;
+}
+
+.woocommerce div.product .np-tab-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 0.5em;
+    font-size: 0.95em;
+}
+
+.np-rich p {
+    margin: 0 0 1em;
+}
+
+.np-spec-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 1.5em;
+    font-size: 0.95em;
+}
+
+.np-spec-table th,
+.np-spec-table td {
+    padding: 0.65em 0.9em;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    text-align: left;
+}
+
+.np-spec-table th {
+    font-weight: 600;
+    width: 40%;
+}
+
+.np-spec-table tr:last-child th,
+.np-spec-table tr:last-child td {
+    border-bottom: 0;
+}

--- a/modules/product-frontend/module.php
+++ b/modules/product-frontend/module.php
@@ -1,0 +1,327 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+class NorPumps_Modules_Product_Frontend {
+    public $app;
+    public $name = 'Producto (Frontend) — Pestañas';
+
+    const OPTION_KEY = 'norpumps_product_frontend_options';
+
+    private $options;
+
+    public function __construct($app) {
+        $this->app = $app;
+        add_filter('woocommerce_product_tabs', [$this, 'filter_tabs'], 99);
+        add_action('wp_enqueue_scripts', [$this, 'enqueue'], 20);
+    }
+
+    public function register_admin_pages() {
+        add_submenu_page(
+            'norpumps',
+            __('Producto (Frontend)', 'norpumps'),
+            __('Producto (Frontend)', 'norpumps'),
+            'manage_options',
+            'norpumps_product_frontend',
+            [$this, 'render_admin']
+        );
+    }
+
+    private function defaults() {
+        return [
+            'enabled' => 1,
+            'labels' => [
+                'rendimientos'     => __('Rendimientos', 'norpumps'),
+                'caracteristicas'  => __('Características', 'norpumps'),
+                'datos_electricos' => __('Datos eléctricos', 'norpumps'),
+            ],
+            'priority' => [
+                'rendimientos'     => 10,
+                'caracteristicas'  => 20,
+                'datos_electricos' => 30,
+            ],
+            'remove_core_tabs' => [
+                'reviews'                => 1,
+                'additional_information' => 1,
+                'description'            => 0,
+            ],
+            'icons' => [
+                'rendimientos'     => '',
+                'caracteristicas'  => '',
+                'datos_electricos' => '',
+            ],
+        ];
+    }
+
+    private function get_options() {
+        if ($this->options !== null) {
+            return $this->options;
+        }
+
+        $stored = get_option(self::OPTION_KEY, []);
+        if (!is_array($stored)) {
+            $stored = [];
+        }
+        $defaults = $this->defaults();
+
+        $stored['labels'] = isset($stored['labels']) && is_array($stored['labels']) ? $stored['labels'] : [];
+        $stored['priority'] = isset($stored['priority']) && is_array($stored['priority']) ? $stored['priority'] : [];
+        $stored['remove_core_tabs'] = isset($stored['remove_core_tabs']) && is_array($stored['remove_core_tabs']) ? $stored['remove_core_tabs'] : [];
+        $stored['icons'] = isset($stored['icons']) && is_array($stored['icons']) ? $stored['icons'] : [];
+
+        $opts = array_merge($defaults, $stored);
+        $opts['labels'] = array_merge($defaults['labels'], $stored['labels']);
+        $opts['priority'] = array_merge($defaults['priority'], $stored['priority']);
+        $opts['remove_core_tabs'] = array_merge($defaults['remove_core_tabs'], $stored['remove_core_tabs']);
+        $opts['icons'] = array_merge($defaults['icons'], $stored['icons']);
+
+        $opts['enabled'] = empty($opts['enabled']) ? 0 : 1;
+
+        $this->options = $opts;
+
+        return $this->options;
+    }
+
+    private function save_options($data) {
+        $defaults = $this->defaults();
+        $clean = $defaults;
+
+        $clean['enabled'] = !empty($data['enabled']) ? 1 : 0;
+
+        $labels = isset($data['labels']) && is_array($data['labels']) ? $data['labels'] : [];
+        foreach ($defaults['labels'] as $key => $default_label) {
+            $clean['labels'][$key] = sanitize_text_field(norpumps_array_get($labels, $key, $default_label));
+        }
+
+        $priority = isset($data['priority']) && is_array($data['priority']) ? $data['priority'] : [];
+        foreach ($defaults['priority'] as $key => $default_priority) {
+            $val = absint(norpumps_array_get($priority, $key, $default_priority));
+            $clean['priority'][$key] = $val > 0 ? $val : $default_priority;
+        }
+
+        $remove = isset($data['remove_core_tabs']) && is_array($data['remove_core_tabs']) ? $data['remove_core_tabs'] : [];
+        foreach ($defaults['remove_core_tabs'] as $key => $default_remove) {
+            $clean['remove_core_tabs'][$key] = !empty($remove[$key]) ? 1 : 0;
+        }
+
+        $icons = isset($data['icons']) && is_array($data['icons']) ? $data['icons'] : [];
+        foreach ($defaults['icons'] as $key => $default_icon) {
+            $icon = sanitize_text_field(norpumps_array_get($icons, $key, $default_icon));
+            $clean['icons'][$key] = trim($icon);
+        }
+
+        update_option(self::OPTION_KEY, $clean, false);
+        $this->options = $clean;
+
+        return $clean;
+    }
+
+    public function render_admin() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        $updated = false;
+        if (!empty($_POST['np_pf_save']) && check_admin_referer('np_pf_options', 'np_pf_nonce')) {
+            $raw = isset($_POST['np_pf']) ? wp_unslash($_POST['np_pf']) : [];
+            $raw = is_array($raw) ? $raw : [];
+            $opts = $this->save_options($raw);
+            $updated = true;
+        } else {
+            $opts = $this->get_options();
+        }
+
+        if ($updated) {
+            echo '<div class="notice notice-success"><p>' . esc_html__('Opciones guardadas.', 'norpumps') . '</p></div>';
+        }
+
+        $labels = $opts['labels'];
+        $priority = $opts['priority'];
+        $remove = $opts['remove_core_tabs'];
+        $icons = $opts['icons'];
+        ?>
+        <div class="wrap norpumps-admin">
+            <h1><?php esc_html_e('Producto (Frontend) — Pestañas personalizadas', 'norpumps'); ?></h1>
+            <p class="desc"><?php esc_html_e('Configura las pestañas visibles en la ficha de producto de WooCommerce.', 'norpumps'); ?></p>
+
+            <form method="post">
+                <?php wp_nonce_field('np_pf_options', 'np_pf_nonce'); ?>
+                <table class="form-table">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Activar módulo', 'norpumps'); ?></th>
+                            <td>
+                                <label>
+                                    <input type="checkbox" name="np_pf[enabled]" value="1" <?php checked(!empty($opts['enabled'])); ?> />
+                                    <?php esc_html_e('Habilitar pestañas personalizadas en el producto', 'norpumps'); ?>
+                                </label>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h2><?php esc_html_e('Pestañas personalizadas', 'norpumps'); ?></h2>
+                <table class="widefat striped">
+                    <thead>
+                        <tr>
+                            <th><?php esc_html_e('Pestaña', 'norpumps'); ?></th>
+                            <th><?php esc_html_e('Título', 'norpumps'); ?></th>
+                            <th><?php esc_html_e('Prioridad', 'norpumps'); ?></th>
+                            <th><?php esc_html_e('Clase(s) de icono', 'norpumps'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><strong><?php esc_html_e('Rendimientos', 'norpumps'); ?></strong></td>
+                            <td><input type="text" name="np_pf[labels][rendimientos]" value="<?php echo esc_attr($labels['rendimientos']); ?>" class="regular-text" /></td>
+                            <td><input type="number" name="np_pf[priority][rendimientos]" value="<?php echo esc_attr($priority['rendimientos']); ?>" min="1" class="small-text" /></td>
+                            <td><input type="text" name="np_pf[icons][rendimientos]" value="<?php echo esc_attr($icons['rendimientos']); ?>" class="regular-text" placeholder="<?php esc_attr_e('ej. e-fas-chevron-right', 'norpumps'); ?>" /></td>
+                        </tr>
+                        <tr>
+                            <td><strong><?php esc_html_e('Características', 'norpumps'); ?></strong></td>
+                            <td><input type="text" name="np_pf[labels][caracteristicas]" value="<?php echo esc_attr($labels['caracteristicas']); ?>" class="regular-text" /></td>
+                            <td><input type="number" name="np_pf[priority][caracteristicas]" value="<?php echo esc_attr($priority['caracteristicas']); ?>" min="1" class="small-text" /></td>
+                            <td><input type="text" name="np_pf[icons][caracteristicas]" value="<?php echo esc_attr($icons['caracteristicas']); ?>" class="regular-text" placeholder="<?php esc_attr_e('ej. e-fas-chevron-right', 'norpumps'); ?>" /></td>
+                        </tr>
+                        <tr>
+                            <td><strong><?php esc_html_e('Datos eléctricos', 'norpumps'); ?></strong></td>
+                            <td><input type="text" name="np_pf[labels][datos_electricos]" value="<?php echo esc_attr($labels['datos_electricos']); ?>" class="regular-text" /></td>
+                            <td><input type="number" name="np_pf[priority][datos_electricos]" value="<?php echo esc_attr($priority['datos_electricos']); ?>" min="1" class="small-text" /></td>
+                            <td><input type="text" name="np_pf[icons][datos_electricos]" value="<?php echo esc_attr($icons['datos_electricos']); ?>" class="regular-text" placeholder="<?php esc_attr_e('ej. e-fas-bolt', 'norpumps'); ?>" /></td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h2><?php esc_html_e('Quitar pestañas nativas de WooCommerce', 'norpumps'); ?></h2>
+                <table class="form-table">
+                    <tbody>
+                        <tr>
+                            <th scope="row"><?php esc_html_e('Pestañas', 'norpumps'); ?></th>
+                            <td>
+                                <label style="display:block;margin-bottom:6px;">
+                                    <input type="checkbox" name="np_pf[remove_core_tabs][reviews]" value="1" <?php checked(!empty($remove['reviews'])); ?> />
+                                    <?php esc_html_e('Valoraciones', 'norpumps'); ?>
+                                </label>
+                                <label style="display:block;margin-bottom:6px;">
+                                    <input type="checkbox" name="np_pf[remove_core_tabs][additional_information]" value="1" <?php checked(!empty($remove['additional_information'])); ?> />
+                                    <?php esc_html_e('Información adicional', 'norpumps'); ?>
+                                </label>
+                                <label style="display:block;margin-bottom:6px;">
+                                    <input type="checkbox" name="np_pf[remove_core_tabs][description]" value="1" <?php checked(!empty($remove['description'])); ?> />
+                                    <?php esc_html_e('Descripción', 'norpumps'); ?>
+                                </label>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <p>
+                    <button type="submit" name="np_pf_save" value="1" class="button button-primary"><?php esc_html_e('Guardar cambios', 'norpumps'); ?></button>
+                </p>
+            </form>
+        </div>
+        <?php
+    }
+
+    public function enqueue() {
+        $opts = $this->get_options();
+        if (empty($opts['enabled']) || !function_exists('is_product') || !is_product()) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'norpumps-product-frontend',
+            NORPUMPS_URL . 'modules/product-frontend/assets/css/product-frontend.css',
+            [],
+            NORPUMPS_VERSION
+        );
+    }
+
+    public function filter_tabs($tabs) {
+        $opts = $this->get_options();
+        if (empty($opts['enabled'])) {
+            return $tabs;
+        }
+
+        $product_id = get_the_ID();
+        if (!$product_id) {
+            return $tabs;
+        }
+
+        foreach ($opts['remove_core_tabs'] as $key => $remove) {
+            if (!empty($remove) && isset($tabs[$key])) {
+                unset($tabs[$key]);
+            }
+        }
+
+        $labels = $opts['labels'];
+        $priority = $opts['priority'];
+        $icons = $opts['icons'];
+
+        $shortcode = trim((string) get_post_meta($product_id, '_np_curva_shortcode', true));
+        if ($shortcode !== '') {
+            $tabs['np_tab_rendimientos'] = [
+                'title'    => $this->format_title($labels['rendimientos'], norpumps_array_get($icons, 'rendimientos', '')),
+                'priority' => max(1, absint($priority['rendimientos'])),
+                'callback' => [$this, 'render_tab_rendimientos'],
+            ];
+        }
+
+        $normas = trim((string) get_post_meta($product_id, '_np_normas', true));
+        $cond = trim((string) get_post_meta($product_id, '_np_condiciones', true));
+        if ($normas !== '' || $cond !== '') {
+            $tabs['np_tab_caracteristicas'] = [
+                'title'    => $this->format_title($labels['caracteristicas'], norpumps_array_get($icons, 'caracteristicas', '')),
+                'priority' => max(1, absint($priority['caracteristicas'])),
+                'callback' => [$this, 'render_tab_caracteristicas'],
+            ];
+        }
+
+        $meta_keys = ['_np_intensidad', '_np_potencia_kw', '_np_potencia_hp', '_np_tension_v'];
+        $has_data = false;
+        foreach ($meta_keys as $meta_key) {
+            $value = trim((string) get_post_meta($product_id, $meta_key, true));
+            if ($value !== '') {
+                $has_data = true;
+                break;
+            }
+        }
+        if ($has_data) {
+            $tabs['np_tab_datos_electricos'] = [
+                'title'    => $this->format_title($labels['datos_electricos'], norpumps_array_get($icons, 'datos_electricos', '')),
+                'priority' => max(1, absint($priority['datos_electricos'])),
+                'callback' => [$this, 'render_tab_datos'],
+            ];
+        }
+
+        return $tabs;
+    }
+
+    private function format_title($label, $icon_class = '') {
+        $label = $label !== '' ? $label : __('Pestaña', 'norpumps');
+        $title = esc_html($label);
+        $icon_class = trim((string) $icon_class);
+        if ($icon_class !== '') {
+            $title = '<span class="np-tab-icon ' . esc_attr($icon_class) . '" aria-hidden="true"></span>' . $title;
+        }
+        return $title;
+    }
+
+    public function render_tab_rendimientos() {
+        $this->include_template('rendimientos');
+    }
+
+    public function render_tab_caracteristicas() {
+        $this->include_template('caracteristicas');
+    }
+
+    public function render_tab_datos() {
+        $this->include_template('datos-electricos');
+    }
+
+    private function include_template($name) {
+        $file = __DIR__ . '/templates/tabs/' . $name . '.php';
+        if (file_exists($file)) {
+            include $file;
+        }
+    }
+}

--- a/modules/product-frontend/templates/tabs/caracteristicas.php
+++ b/modules/product-frontend/templates/tabs/caracteristicas.php
@@ -1,0 +1,21 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+$normas = trim((string) get_post_meta(get_the_ID(), '_np_normas', true));
+$condiciones = trim((string) get_post_meta(get_the_ID(), '_np_condiciones', true));
+
+if ($normas === '' && $condiciones === '') {
+    return;
+}
+?>
+<div class="np-tab np-tab--caracteristicas">
+    <?php if ($normas !== '') : ?>
+        <h3><?php esc_html_e('Normas y Tolerancias', 'norpumps'); ?></h3>
+        <div class="np-rich"><?php echo wpautop(wp_kses_post($normas)); ?></div>
+    <?php endif; ?>
+
+    <?php if ($condiciones !== '') : ?>
+        <h3><?php esc_html_e('Condiciones de Operación', 'norpumps'); ?></h3>
+        <div class="np-rich"><?php echo wpautop(wp_kses_post($condiciones)); ?></div>
+    <?php endif; ?>
+</div>

--- a/modules/product-frontend/templates/tabs/datos-electricos.php
+++ b/modules/product-frontend/templates/tabs/datos-electricos.php
@@ -1,0 +1,35 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+$rows = [
+    ['Intensidad nominal (A)', '_np_intensidad'],
+    ['Potencia motor (kW)', '_np_potencia_kw'],
+    ['Potencia motor (HP)', '_np_potencia_hp'],
+    ['Tensión nominal (V)', '_np_tension_v'],
+];
+
+$values = [];
+foreach ($rows as $row) {
+    list($label, $meta_key) = $row;
+    $value = trim((string) get_post_meta(get_the_ID(), $meta_key, true));
+    if ($value !== '') {
+        $values[] = [$label, $value];
+    }
+}
+
+if (!$values) {
+    return;
+}
+?>
+<div class="np-tab np-tab--datos-electricos">
+    <table class="np-spec-table">
+        <tbody>
+            <?php foreach ($values as $item) : ?>
+                <tr>
+                    <th scope="row"><?php echo esc_html($item[0]); ?></th>
+                    <td><?php echo esc_html($item[1]); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/modules/product-frontend/templates/tabs/rendimientos.php
+++ b/modules/product-frontend/templates/tabs/rendimientos.php
@@ -1,0 +1,11 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+$shortcode = trim((string) get_post_meta(get_the_ID(), '_np_curva_shortcode', true));
+if ($shortcode === '') {
+    return;
+}
+?>
+<div class="np-tab np-tab--rendimientos">
+    <?php echo do_shortcode($shortcode); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+</div>

--- a/norpumps.php
+++ b/norpumps.php
@@ -38,6 +38,7 @@ class NorPumps_App {
         // Módulos
         $this->register_module('store', 'NorPumps_Modules_Store');
         $this->register_module('techsheet', 'NorPumps_Modules_Techsheet'); // NUEVO módulo de metacampos
+        $this->register_module('product-frontend', 'NorPumps_Modules_Product_Frontend');
         do_action('norpumps_register_modules', $this);
     }
     public function register_module($slug, $class){


### PR DESCRIPTION
## Summary
- add a product frontend module that replaces WooCommerce product tabs with custom Rendimientos, Características, and Datos eléctricos sections
- provide an admin settings page to control activation, labels, priorities, icons, and removal of native tabs
- supply frontend templates and lightweight styles for rendering the new tab content

## Testing
- php -l modules/product-frontend/module.php
- php -l modules/product-frontend/templates/tabs/rendimientos.php
- php -l modules/product-frontend/templates/tabs/caracteristicas.php
- php -l modules/product-frontend/templates/tabs/datos-electricos.php

------
https://chatgpt.com/codex/tasks/task_e_68ee89f6c62c8330bd6772de589e234b