### PR TITLE
Improve product specification table contrast

### DIFF
--- a/modules/product-frontend/assets/css/product-frontend.css
+++ b/modules/product-frontend/assets/css/product-frontend.css
@@ -31,6 +31,13 @@
 .np-spec-table th {
     font-weight: 600;
     width: 40%;
+    background: #f4f5f5;
+    color: #111;
+}
+
+.np-spec-table td {
+    background: #115B6A;
+    color: #fff;
 }
 
 .np-spec-table tr:last-child th,


### PR DESCRIPTION
## Summary
- ensure the product specification table labels use a dark text color on the light background for readability
- update the specification value cells to use the requested #115B6A accent color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eeb84770d4833080ed4624fef8d746