### PR TITLE
Adjust spec table text contrast dynamically

### DIFF
--- a/modules/product-frontend/assets/js/product-frontend.js
+++ b/modules/product-frontend/assets/js/product-frontend.js
@@ -1,0 +1,154 @@
+(function () {
+    'use strict';
+
+    function parseRgb(color) {
+        var match = color.match(/rgba?\(([^)]+)\)/);
+        if (!match) {
+            return null;
+        }
+
+        var parts = match[1].split(',').map(function (part) {
+            return part.trim();
+        });
+
+        if (parts.length < 3) {
+            return null;
+        }
+
+        var r = parseFloat(parts[0]);
+        var g = parseFloat(parts[1]);
+        var b = parseFloat(parts[2]);
+        var a = parts.length >= 4 ? parseFloat(parts[3]) : 1;
+
+        if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b) || Number.isNaN(a)) {
+            return null;
+        }
+
+        return { r: r, g: g, b: b, a: a };
+    }
+
+    function isTransparent(color) {
+        if (!color) {
+            return true;
+        }
+
+        if (color === 'transparent') {
+            return true;
+        }
+
+        var rgb = parseRgb(color);
+        if (!rgb) {
+            return false;
+        }
+
+        return rgb.a === 0;
+    }
+
+    function getEffectiveBackground(element) {
+        var el = element;
+        while (el && el !== document.documentElement) {
+            var style = window.getComputedStyle(el);
+            if (style) {
+                var bg = style.backgroundColor;
+                if (!isTransparent(bg)) {
+                    return bg;
+                }
+            }
+            el = el.parentElement;
+        }
+        return 'rgb(255, 255, 255)';
+    }
+
+    function relativeLuminance(channel) {
+        var normalized = channel / 255;
+        if (normalized <= 0.03928) {
+            return normalized / 12.92;
+        }
+        return Math.pow((normalized + 0.055) / 1.055, 2.4);
+    }
+
+    function getContrastColor(rgb) {
+        var luminance = 0.2126 * relativeLuminance(rgb.r) +
+            0.7152 * relativeLuminance(rgb.g) +
+            0.0722 * relativeLuminance(rgb.b);
+
+        var contrastWithBlack = (luminance + 0.05) / 0.05;
+        var contrastWithWhite = 1.05 / (luminance + 0.05);
+
+        if (contrastWithBlack >= contrastWithWhite) {
+            return '#111111';
+        }
+
+        return '#ffffff';
+    }
+
+    function applyColor(cell) {
+        var bgColor = getEffectiveBackground(cell);
+        var rgb = parseRgb(bgColor);
+        if (!rgb) {
+            return;
+        }
+
+        var textColor = getContrastColor(rgb);
+        cell.style.setProperty('color', textColor, 'important');
+    }
+
+    function enhanceRow(row) {
+        var labelCell = row.querySelector('.np-spec-table__cell--label');
+        if (!labelCell) {
+            return;
+        }
+
+        var apply = function () {
+            applyColor(labelCell);
+        };
+
+        apply();
+
+        row.addEventListener('mouseenter', apply);
+        row.addEventListener('mouseleave', apply);
+        row.addEventListener('focusin', apply);
+        row.addEventListener('focusout', apply);
+    }
+
+    function setup(table) {
+        var rows = table.querySelectorAll('.np-spec-table__row');
+        rows.forEach(enhanceRow);
+
+        var observer = new MutationObserver(function (mutations) {
+            mutations.forEach(function (mutation) {
+                mutation.addedNodes.forEach(function (node) {
+                    if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains('np-spec-table__row')) {
+                        enhanceRow(node);
+                    }
+                });
+
+                if (mutation.type === 'attributes' && mutation.target.classList.contains('np-spec-table__row')) {
+                    enhanceRow(mutation.target);
+                }
+            });
+        });
+
+        observer.observe(table, {
+            childList: true,
+            attributes: true,
+            subtree: true,
+            attributeFilter: ['class']
+        });
+    }
+
+    function init() {
+        var table = document.querySelector('.np-tab--datos-electricos .np-spec-table');
+        if (!table) {
+            return;
+        }
+
+        setup(table);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/modules/product-frontend/module.php
+++ b/modules/product-frontend/module.php
@@ -234,6 +234,14 @@ class NorPumps_Modules_Product_Frontend {
             [],
             NORPUMPS_VERSION
         );
+
+        wp_enqueue_script(
+            'norpumps-product-frontend',
+            NORPUMPS_URL . 'modules/product-frontend/assets/js/product-frontend.js',
+            [],
+            NORPUMPS_VERSION,
+            true
+        );
     }
 
     public function filter_tabs($tabs) {


### PR DESCRIPTION
## Summary
- add a frontend script that adjusts the electric data table label colors based on their background for better contrast
- enqueue the new script with the existing product frontend assets

## Testing
- php -l modules/product-frontend/module.php

------
https://chatgpt.com/codex/tasks/task_e_68eed28b604c83308d9648e379aaeac1