### PR TITLE
Stop hover effects on specification labels

### DIFF
--- a/modules/product-frontend/assets/css/product-frontend.css
+++ b/modules/product-frontend/assets/css/product-frontend.css
@@ -57,11 +57,6 @@
     color: #fff;
 }
 
-.np-tab--datos-electricos .np-spec-table__row:hover .np-spec-table__cell--label {
-    background: #d2d7d7;
-    color: #111;
-}
-
 .np-tab--datos-electricos .np-spec-table__row:hover .np-spec-table__cell--value {
     background: #0b4150;
     color: #fff;


### PR DESCRIPTION
## Summary
- remove the hover styling that altered specification label backgrounds so only the value cells react to hover

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eed5d0bf588330bc9f7b7eda51e633