### PR TITLE
Remove hover styling from specification table

### DIFF
--- a/modules/product-frontend/assets/css/product-frontend.css
+++ b/modules/product-frontend/assets/css/product-frontend.css
@@ -57,16 +57,6 @@
     color: #fff;
 }
 
-.np-tab--datos-electricos .np-spec-table__row:hover .np-spec-table__cell--label {
-    background: #d2d7d7;
-    color: #111;
-}
-
-.np-tab--datos-electricos .np-spec-table__row:hover .np-spec-table__cell--value {
-    background: #0b4150;
-    color: #fff;
-}
-
 .np-spec-table tr:last-child th,
 .np-spec-table tr:last-child td {
     border-bottom: 0;


### PR DESCRIPTION
## Summary
- remove the hover-state styling from the electric specification table so labels retain the JS-managed text contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eed80eb6708330b1938141f32e96bd