### PR TITLE
Stop hover styles overriding spec table contrast

### DIFF
--- a/modules/product-frontend/assets/css/product-frontend.css
+++ b/modules/product-frontend/assets/css/product-frontend.css
@@ -37,24 +37,32 @@
     font-weight: 600;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--label {
-    background: #f4f5f5;
-    color: #111;
+.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--label,
+.np-tab--datos-electricos .np-spec-table__row.is-odd:hover .np-spec-table__cell--label {
+    background: #f4f5f5 !important;
+    color: #111 !important;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--value {
-    background: #115B6A;
-    color: #fff;
+.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--value,
+.np-tab--datos-electricos .np-spec-table__row.is-odd:hover .np-spec-table__cell--value {
+    background: #115B6A !important;
+    color: #fff !important;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--label {
-    background: #e3e6e6;
-    color: #111;
+.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--label,
+.np-tab--datos-electricos .np-spec-table__row.is-even:hover .np-spec-table__cell--label {
+    background: #e3e6e6 !important;
+    color: #111 !important;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--value {
-    background: #0d4f5c;
-    color: #fff;
+.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--value,
+.np-tab--datos-electricos .np-spec-table__row.is-even:hover .np-spec-table__cell--value {
+    background: #0d4f5c !important;
+    color: #fff !important;
+}
+
+.np-tab--datos-electricos .np-spec-table__row:hover {
+    background: transparent !important;
 }
 
 .np-spec-table tr:last-child th,


### PR DESCRIPTION
## Summary
- keep datos eléctricos spec table cells locked to their intended background/text colors even on hover
- neutralize inherited hover styling on the table rows so no highlight is applied when hovering

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68eeda69b4f48330b8a892d085723764