### PR TITLE
Ensure product spec table colors resist hover overrides

### DIFF
--- a/modules/product-frontend/assets/css/product-frontend.css
+++ b/modules/product-frontend/assets/css/product-frontend.css
@@ -37,26 +37,22 @@
     font-weight: 600;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--label,
-.np-tab--datos-electricos .np-spec-table__row.is-odd:hover .np-spec-table__cell--label {
+.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--label {
     background: #f4f5f5 !important;
     color: #111 !important;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--value,
-.np-tab--datos-electricos .np-spec-table__row.is-odd:hover .np-spec-table__cell--value {
+.np-tab--datos-electricos .np-spec-table__row.is-odd .np-spec-table__cell--value {
     background: #115B6A !important;
     color: #fff !important;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--label,
-.np-tab--datos-electricos .np-spec-table__row.is-even:hover .np-spec-table__cell--label {
+.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--label {
     background: #e3e6e6 !important;
     color: #111 !important;
 }
 
-.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--value,
-.np-tab--datos-electricos .np-spec-table__row.is-even:hover .np-spec-table__cell--value {
+.np-tab--datos-electricos .np-spec-table__row.is-even .np-spec-table__cell--value {
     background: #0d4f5c !important;
     color: #fff !important;
 }

--- a/modules/product-frontend/assets/js/product-frontend.js
+++ b/modules/product-frontend/assets/js/product-frontend.js
@@ -82,8 +82,43 @@
         return '#ffffff';
     }
 
-    function applyColor(cell) {
-        var bgColor = getEffectiveBackground(cell);
+    function freezeBackground(cell) {
+        var stored = cell.getAttribute('data-np-base-bg');
+        if (!stored) {
+            stored = getEffectiveBackground(cell);
+            if (stored) {
+                cell.setAttribute('data-np-base-bg', stored);
+            }
+        }
+
+        if (!stored) {
+            return null;
+        }
+
+        cell.style.setProperty('background-color', stored, 'important');
+        cell.style.setProperty('background', stored, 'important');
+
+        return stored;
+    }
+
+    function freezeTextColor(cell) {
+        var stored = cell.getAttribute('data-np-base-color');
+        if (!stored) {
+            stored = window.getComputedStyle(cell).color;
+            if (stored) {
+                cell.setAttribute('data-np-base-color', stored);
+            }
+        }
+
+        if (!stored) {
+            return;
+        }
+
+        cell.style.setProperty('color', stored, 'important');
+    }
+
+    function applyContrast(cell, background) {
+        var bgColor = background || getEffectiveBackground(cell);
         var rgb = parseRgb(bgColor);
         if (!rgb) {
             return;
@@ -95,12 +130,19 @@
 
     function enhanceRow(row) {
         var labelCell = row.querySelector('.np-spec-table__cell--label');
+        var valueCell = row.querySelector('.np-spec-table__cell--value');
         if (!labelCell) {
             return;
         }
 
         var apply = function () {
-            applyColor(labelCell);
+            var labelBg = freezeBackground(labelCell);
+            applyContrast(labelCell, labelBg);
+
+            if (valueCell) {
+                freezeBackground(valueCell);
+                freezeTextColor(valueCell);
+            }
         };
 
         apply();


### PR DESCRIPTION
## Summary
- lock the electric data spec table cell colors without hover state selectors so external styles cannot override them
- enhance the contrast script to persist background and text colors even when hover styles attempt to change them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eedc5addcc8330bab24f0c5d5223e5