### PR TITLE
Align store grid add-to-cart behavior with WooCommerce

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -30,6 +30,7 @@
 .np-card__title{ font-size:16px; margin:6px 0 8px; min-height:44px; }
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
+.np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
 .np-pagination{ margin:20px 0; text-align:center; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }

--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -108,6 +108,9 @@ class NorPumps_Modules_Store {
             $parts = array_map('trim', explode(':',$chunk,2));
             if (count($parts)==2){ $label = sanitize_text_field($parts[0]); $slug = sanitize_title($parts[1]); if ($slug) $groups[]=['label'=>$label?:$slug,'slug'=>$slug]; }
         }
+        wp_enqueue_script('wc-add-to-cart');
+        wp_enqueue_script('wc-cart-fragments');
+        wp_enqueue_style('woocommerce-general');
         ob_start();
         $filters_arr = array_filter(array_map('trim', explode(',', $atts['filters'])));
         include __DIR__.'/templates/store.php';

--- a/modules/store/templates/card.php
+++ b/modules/store/templates/card.php
@@ -1,5 +1,5 @@
 <?php if (!defined('ABSPATH')) { exit; } global $product; ?>
-<article class="np-card">
+<article class="np-card product">
   <a class="np-card__image" href="<?php echo esc_url(get_permalink($product->get_id())); ?>">
     <?php echo $product->get_image('woocommerce_thumbnail'); ?>
   </a>

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -75,7 +75,7 @@ if (!isset($filters_arr)) $filters_arr = [];
     </aside>
 
     <section class="norpumps-grid">
-      <div class="np-grid js-np-grid" data-columns="<?php echo esc_attr($columns); ?>"></div>
+      <div class="np-grid js-np-grid products" data-columns="<?php echo esc_attr($columns); ?>"></div>
       <div class="np-pagination js-np-pagination"></div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- add WooCommerce `products`/`product` classes to the store grid container and cards so theme styles apply
- enqueue WooCommerce cart scripts/styles for the shortcode to ensure AJAX buttons update state
- provide a fallback checkmark pseudo-element for added buttons when themes lack styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68efc67bdaf88330bb6b5d71b197afb3