### PR TITLE
Add filter-aware pagination to store module

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -31,7 +31,16 @@
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
 .np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
-.np-pagination{ margin:20px 0; text-align:center; }
+.np-pagination{ margin:20px 0; text-align:center; display:flex; flex-direction:column; gap:12px; align-items:center; }
+.np-pagination__summary{ font-size:14px; color:#52626c; }
+.np-pagination__list{ list-style:none; display:flex; gap:6px; padding:0; margin:0; }
+.np-page-item{ }
+.np-page-item .np-page-link{ min-width:38px; padding:8px 12px; border:1px solid var(--np-border); border-radius:10px; background:#fff; color:var(--np-text); font-weight:600; transition:all .2s ease; }
+.np-page-item .np-page-link:hover:not(:disabled){ border-color:var(--np-accent); color:var(--np-accent); box-shadow:0 4px 10px rgba(15,91,98,0.12); }
+.np-page-item.is-disabled .np-page-link{ opacity:.5; cursor:not-allowed; }
+.np-page-item.is-active .np-page-link{ background:var(--np-accent); color:#fff; border-color:var(--np-accent); box-shadow:0 6px 16px rgba(15,91,98,0.25); }
+.np-page-item.np-ellipsis{ align-self:center; color:#9aa7ad; padding:0 6px; }
+.np-pagination__nav{ display:flex; justify-content:center; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,5 +1,17 @@
 jQuery(function($){
   function clamp(v,a,b){ v=parseFloat(v||0); return Math.min(Math.max(v,a), b); }
+  function setPage($root, page){
+    const target = parseInt(page, 10);
+    $root.data('currentPage', (isNaN(target) || target<1) ? 1 : target);
+  }
+  function getPage($root){
+    const stored = parseInt($root.data('currentPage'), 10);
+    return (!isNaN(stored) && stored>0) ? stored : 1;
+  }
+  function getPerPage($root){
+    const per = parseInt($root.data('perPage'), 10);
+    return (!isNaN(per) && per>0) ? per : 12;
+  }
   function syncPriceUI($root){
     const $wrap = $root.find('.np-price__slider'); if (!$wrap.length) return {};
     const min = parseFloat($wrap.data('min')), max = parseFloat($wrap.data('max'));
@@ -10,15 +22,39 @@ jQuery(function($){
     return {min:vmin, max:vmax};
   }
   function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
-    data.orderby = $root.find('.np-orderby select').val();
-    const q = $root.find('.np-search').val(); if (q) data.s = q;
-    const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
-    $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
-      const group = $(this).data('group');
-      const vals = $(this).find('input:checked').map(function(){return this.value;}).get();
-      const allOn = $(this).closest('.np-filter__body').find('.np-all-toggle').is(':checked');
-      if (vals.length && !allOn) data['cat_'+group] = vals.join(',');
+    const data = {
+      action:'norpumps_store_query',
+      nonce:NorpumpsStore.nonce,
+      per_page:getPerPage($root),
+      page:getPage($root)
+    };
+    const pr = syncPriceUI($root);
+    if (pr.min!=null) data.min_price = pr.min;
+    if (pr.max!=null) data.max_price = pr.max;
+    $root.find('.np-checklist[data-param]').each(function(){
+      const $checklist = $(this);
+      const param = $checklist.data('param');
+      const vals = $checklist.find('input:checked').map(function(){ return this.value; }).get();
+      const $body = $checklist.closest('.np-filter__body');
+      const allOn = $body.find('.np-all-toggle').is(':checked');
+      if (vals.length && !allOn) data[param] = vals.join(',');
+    });
+    $root.find('[data-param]').each(function(){
+      const $el = $(this);
+      const param = $el.data('param');
+      if (!param || data[param]!==undefined) return;
+      if ($el.closest('.np-checklist[data-param]').length) return;
+      if ($el.is('input, select, textarea')){
+        const type = ($el.attr('type')||'').toLowerCase();
+        if (type==='checkbox'){
+          if ($el.is(':checked')) data[param] = $el.val() || 'on';
+        } else if (type==='radio'){
+          if ($el.is(':checked')) data[param] = $el.val();
+        } else {
+          const val = $el.val();
+          if (val!=='' && val!=null) data[param] = val;
+        }
+      }
     });
     return data;
   }
@@ -27,19 +63,82 @@ jQuery(function($){
     Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
     return p.toString();
   }
+  function renderPagination($root, meta){
+    const $pagination = $root.find('.js-np-pagination');
+    const current = meta && meta.current ? parseInt(meta.current,10) : 1;
+    const totalPages = meta && meta.total_pages ? parseInt(meta.total_pages,10) : 1;
+    const perPage = meta && meta.per_page ? parseInt(meta.per_page,10) : getPerPage($root);
+    const total = meta && meta.total ? parseInt(meta.total,10) : 0;
+    const safeCurrent = (!isNaN(current) && current>0) ? current : 1;
+    const safeTotalPages = (!isNaN(totalPages) && totalPages>0) ? totalPages : 1;
+    setPage($root, safeCurrent);
+    const start = total===0 ? 0 : ((safeCurrent-1)*perPage)+1;
+    const end = total===0 ? 0 : Math.min(total, safeCurrent*perPage);
+    const $summary = $('<div/>', { 'class':'np-pagination__summary', text: total>0 ? `Mostrando ${start}–${end} de ${total}` : 'Sin resultados' });
+    if (safeTotalPages<=1){
+      $pagination.empty().append($summary);
+      return;
+    }
+    const pages = [];
+    const span = 2;
+    const bucket = new Set([1, safeTotalPages]);
+    for (let i = safeCurrent - span; i <= safeCurrent + span; i++){
+      if (i>=1 && i<=safeTotalPages) bucket.add(i);
+    }
+    const sorted = Array.from(bucket).sort((a,b)=>a-b);
+    sorted.forEach((page, idx)=>{
+      if (idx>0 && page - sorted[idx-1] > 1) pages.push('ellipsis');
+      pages.push(page);
+    });
+    const $nav = $('<nav/>', { 'class':'np-pagination__nav', 'aria-label':'Paginación de productos' });
+    const $list = $('<ul/>', { 'class':'np-pagination__list' });
+    function createButton(label, page, disabled, extraClass, ariaLabel){
+      const $li = $('<li/>', { 'class':'np-page-item'+(extraClass?` ${extraClass}`:'') });
+      const $btn = $('<button/>', {
+        type:'button',
+        'class':'np-page-link',
+        'aria-label':ariaLabel || label,
+        'data-page':page
+      }).text(label);
+      if (disabled){
+        $btn.prop('disabled', true).attr('aria-disabled','true');
+        $li.addClass('is-disabled');
+      }
+      $li.append($btn);
+      return $li;
+    }
+    $list.append(createButton('‹', safeCurrent-1, safeCurrent<=1, 'np-prev', 'Página anterior'));
+    pages.forEach(item=>{
+      if (item==='ellipsis'){
+        $list.append($('<li/>', { 'class':'np-page-item np-ellipsis', text:'…' }));
+      } else {
+        const isActive = item===safeCurrent;
+        const $li = createButton(String(item), item, false, isActive?'is-active':'');
+        if (isActive) $li.find('button').attr('aria-current','page');
+        $list.append($li);
+      }
+    });
+    $list.append(createButton('›', safeCurrent+1, safeCurrent>=safeTotalPages, 'np-next', 'Página siguiente'));
+    $nav.append($list);
+    $pagination.empty().append($summary).append($nav);
+  }
   function load($root){
     const data = buildQuery($root);
-    const qs = toQuery(data);
+    const params = Object.assign({}, data);
+    if (params.page<=1) delete params.page;
+    const qs = toQuery(params);
     history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
     $.post(NorpumpsStore.ajax_url, data, function(resp){
       if (!resp || !resp.success) return;
       $root.find('.js-np-grid').html(resp.data.html);
+      renderPagination($root, resp.data.pagination || null);
     });
   }
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
+      setPage($root, 1);
       load($root);
     });
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
@@ -47,26 +146,62 @@ jQuery(function($){
       if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
       const anyChecked = $body.find('.np-checklist input:checked').length>0;
       if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
+      setPage($root, 1);
       load($root);
     });
   }
   $('.norpumps-store').each(function(){
     const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
+    setPage($root, 1);
+    $root.on('change', '.np-orderby select', function(){
+      setPage($root, 1);
+      load($root);
+    });
+    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); })
+         .on('change', '.np-price__slider input[type=range]', function(){ setPage($root, 1); load($root); });
+    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13){ setPage($root,1); load($root); } });
+    $root.on('click', '.np-pagination .np-page-link', function(){
+      const target = parseInt($(this).data('page'),10);
+      if (!isNaN(target)){ setPage($root, target); load($root); }
+    });
+    $root.on('change', '[data-param]', function(){
+      const $el = $(this);
+      if ($el.is('.np-orderby select') || $el.hasClass('np-search') || $el.hasClass('np-range-min') || $el.hasClass('np-range-max')) return;
+      if ($el.closest('.np-checklist[data-param]').length) return;
+      setPage($root, 1);
+      load($root);
+    });
     bindAllToggle($root);
     const url = new URL(window.location.href);
     const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
     if (pmin!=null) $root.find('.np-range-min').val(pmin);
     if (pmax!=null) $root.find('.np-range-max').val(pmax);
+    const initialPage = url.searchParams.get('page');
+    if (initialPage) setPage($root, parseInt(initialPage,10));
+    $root.find('[data-param]').each(function(){
+      const $el = $(this); const param = $el.data('param');
+      if (!param || !$el.is('input, select, textarea')) return;
+      if ($el.closest('.np-checklist[data-param]').length) return;
+      const value = url.searchParams.get(param);
+      if (value==null) return;
+      const type = ($el.attr('type')||'').toLowerCase();
+      if (type==='checkbox'){
+        $el.prop('checked', value===($el.val()||'on'));
+      } else if (type==='radio'){
+        if ($el.val()===value) $el.prop('checked', true);
+      } else {
+        $el.val(value);
+      }
+    });
     syncPriceUI($root);
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
-      const group = $(this).data('group'); const key = 'cat_'+group;
-      const vals = (url.searchParams.get(key)||'').split(',').filter(Boolean);
+      const $checklist = $(this);
+      const param = $checklist.data('param');
+      const vals = (url.searchParams.get(param)||'').split(',').filter(Boolean);
       if (vals.length){
-        const $body = $(this).closest('.np-filter__body'); $body.find('.np-all-toggle').prop('checked', false);
-        $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });
+        const $body = $checklist.closest('.np-filter__body');
+        $body.find('.np-all-toggle').prop('checked', false);
+        $checklist.find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });
       }
     });
     load($root);

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -5,11 +5,11 @@ $price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr(intval($atts['per_page'])); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
-      <select class="np-orderby">
+      <select class="np-orderby" data-param="orderby">
         <option value="menu_order title"><?php esc_html_e('Predeterminado','norpumps'); ?></option>
         <option value="price"><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
         <option value="price-desc"><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
@@ -18,7 +18,7 @@ if (!isset($filters_arr)) $filters_arr = [];
       </select>
     </div>
     <div class="norpumps-store__search">
-      <input type="search" class="np-search" placeholder="<?php esc_attr_e('Buscar productos…','norpumps'); ?>">
+      <input type="search" class="np-search" data-param="s" placeholder="<?php esc_attr_e('Buscar productos…','norpumps'); ?>">
     </div>
   </div>
 
@@ -30,8 +30,8 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__body">
           <div class="np-price">
             <div class="np-price__slider" data-min="<?php echo esc_attr($price_min); ?>" data-max="<?php echo esc_attr($price_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
+              <input type="range" class="np-range-min" data-param="min_price" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
+              <input type="range" class="np-range-max" data-param="max_price" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
             </div>
             <div class="np-price__labels">
               <span class="np-price-min"><?php echo esc_html($price_min); ?></span>
@@ -53,7 +53,7 @@ if (!isset($filters_arr)) $filters_arr = [];
               <?php if ($show_all): ?>
                 <label class="np-all"><input type="checkbox" class="np-all-toggle" checked> <?php esc_html_e('Todos','norpumps'); ?></label>
               <?php endif; ?>
-              <div class="np-checklist" data-tax="product_cat" data-group="<?php echo esc_attr($g['slug']); ?>">
+              <div class="np-checklist" data-tax="product_cat" data-group="<?php echo esc_attr($g['slug']); ?>" data-param="<?php echo esc_attr('cat_'.$g['slug']); ?>">
                 <?php
                 // IMPORTANT: avoid function redeclare fatals in REST/editor
                 if (!function_exists('np_render_children_only')){


### PR DESCRIPTION
## Summary
- add pagination metadata from the store query endpoint so the frontend knows total pages and preserves filters
- refresh the storefront template and script to persist filters, sync the URL, and render accessible pagination controls
- style the pagination component to match the shop design while showing result counts

## Testing
- not run (WordPress environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68efe8b17d448330acdda435523fc398