### PR TITLE
Improve store pagination and preserve filters

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -30,7 +30,15 @@
 .np-card__title{ font-size:16px; margin:6px 0 8px; min-height:44px; }
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
-.np-pagination{ margin:20px 0; text-align:center; }
+.np-pagination{ margin:24px 0; text-align:center; display:flex; flex-direction:column; align-items:center; gap:12px; }
+.np-pagination__nav{ display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:8px; }
+.np-page-btn{ min-width:38px; min-height:38px; padding:8px 12px; border:1px solid var(--np-border); border-radius:8px; background:#fff; color:var(--np-text); font-weight:600; cursor:pointer; transition:all .2s ease; }
+.np-page-btn:hover{ border-color:var(--np-accent); color:var(--np-accent); }
+.np-page-btn.is-active, .np-page-btn[aria-current]{ background:var(--np-accent); border-color:var(--np-accent); color:#fff; cursor:default; }
+.np-page-btn:disabled{ opacity:.45; cursor:not-allowed; }
+.np-page-sep{ padding:0 6px; color:#7b8a92; }
+.np-pagination__summary{ font-size:14px; color:#4a565c; }
+.norpumps-store.is-loading .js-np-grid{ opacity:.6; pointer-events:none; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -31,7 +31,15 @@
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
 .np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
-.np-pagination{ margin:20px 0; text-align:center; }
+.np-pagination{ margin:24px 0; text-align:center; display:flex; flex-direction:column; align-items:center; gap:12px; }
+.np-pagination__nav{ display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:8px; }
+.np-page-btn{ min-width:38px; min-height:38px; padding:8px 12px; border:1px solid var(--np-border); border-radius:8px; background:#fff; color:var(--np-text); font-weight:600; cursor:pointer; transition:all .2s ease; }
+.np-page-btn:hover{ border-color:var(--np-accent); color:var(--np-accent); }
+.np-page-btn.is-active, .np-page-btn[aria-current]{ background:var(--np-accent); border-color:var(--np-accent); color:#fff; cursor:default; }
+.np-page-btn:disabled{ opacity:.45; cursor:not-allowed; }
+.np-page-sep{ padding:0 6px; color:#7b8a92; }
+.np-pagination__summary{ font-size:14px; color:#4a565c; }
+.norpumps-store.is-loading .js-np-grid{ opacity:.6; pointer-events:none; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -9,66 +9,229 @@ jQuery(function($){
     $root.find('.np-price-min').text(vmin); $root.find('.np-price-max').text(vmax);
     return {min:vmin, max:vmax};
   }
-  function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
-    data.orderby = $root.find('.np-orderby select').val();
-    const q = $root.find('.np-search').val(); if (q) data.s = q;
-    const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
-    $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
-      const group = $(this).data('group');
-      const vals = $(this).find('input:checked').map(function(){return this.value;}).get();
-      const allOn = $(this).closest('.np-filter__body').find('.np-all-toggle').is(':checked');
-      if (vals.length && !allOn) data['cat_'+group] = vals.join(',');
-    });
-    return data;
-  }
   function toQuery(obj){
     const p = new URLSearchParams();
-    Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
-    return p.toString();
-  }
-  function load($root){
-    const data = buildQuery($root);
-    const qs = toQuery(data);
-    history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
-    $.post(NorpumpsStore.ajax_url, data, function(resp){
-      if (!resp || !resp.success) return;
-      $root.find('.js-np-grid').html(resp.data.html);
-    });
-  }
-  function bindAllToggle($root){
-    $root.on('change', '.np-all-toggle', function(){
-      const $body = $(this).closest('.np-filter__body');
-      $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
-      load($root);
-    });
-    $root.on('change', '.np-checklist input[type=checkbox]', function(){
-      const $body = $(this).closest('.np-filter__body');
-      if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
-      const anyChecked = $body.find('.np-checklist input:checked').length>0;
-      if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
-      load($root);
-    });
-  }
-  $('.norpumps-store').each(function(){
-    const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
-    bindAllToggle($root);
-    const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
-    if (pmin!=null) $root.find('.np-range-min').val(pmin);
-    if (pmax!=null) $root.find('.np-range-max').val(pmax);
-    syncPriceUI($root);
-    $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
-      const group = $(this).data('group'); const key = 'cat_'+group;
-      const vals = (url.searchParams.get(key)||'').split(',').filter(Boolean);
-      if (vals.length){
-        const $body = $(this).closest('.np-filter__body'); $body.find('.np-all-toggle').prop('checked', false);
-        $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });
+    Object.keys(obj).forEach(k=>{
+      if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null){
+        p.set(k,obj[k]);
       }
     });
-    load($root);
+    return p.toString();
+  }
+  function renderPagination($root, meta, state){
+    const $pagination = $root.find('.js-np-pagination');
+    const totalItems = parseInt(meta.total_items,10) || 0;
+    const perPage = parseInt(meta.per_page,10) || state.perPage || 1;
+    let totalPages = parseInt(meta.total_pages,10);
+    if (!totalPages){ totalPages = totalItems ? Math.max(1, Math.ceil(totalItems/perPage)) : 0; }
+    let current = parseInt(meta.current_page,10) || state.page || 1;
+    if (totalPages){ current = Math.min(Math.max(current,1), totalPages); }
+    state.page = current;
+    state.perPage = perPage;
+    $root.data('perPage', perPage);
+
+    if (!totalItems){
+      $pagination.html('<div class="np-pagination__summary">No se encontraron productos.</div>').show();
+      return;
+    }
+    if (totalPages<=1){
+      const from = ((current-1)*perPage)+1;
+      const to = Math.min(totalItems, current*perPage);
+      $pagination.html('<div class="np-pagination__summary">Mostrando '+from+'–'+to+' de '+totalItems+' productos</div>').show();
+      return;
+    }
+
+    let html = '<nav class="np-pagination__nav" aria-label="Paginación">';
+    html += '<button type="button" class="np-page-btn np-page-prev" data-page="'+(current-1)+'" aria-label="Página anterior"'+(current<=1?' disabled':'')+'>&lsaquo;</button>';
+
+    const windowSize = 2;
+    const pages = [];
+    const start = Math.max(1, current-windowSize);
+    const end = Math.min(totalPages, current+windowSize);
+    pages.push(1);
+    for (let i=start;i<=end;i++){ pages.push(i); }
+    pages.push(totalPages);
+    const uniquePages = Array.from(new Set(pages.filter(n=>n>=1 && n<=totalPages))).sort((a,b)=>a-b);
+    let prev = 0;
+    uniquePages.forEach(function(page){
+      if (prev && page-prev>1){ html += '<span class="np-page-sep" aria-hidden="true">…</span>'; }
+      const isCurrent = page===current;
+      html += '<button type="button" class="np-page-btn'+(isCurrent?' is-active':'')+'" data-page="'+page+'"'+(isCurrent?' aria-current="page"':' aria-label="Ir a la página '+page+'"')+(isCurrent?' disabled':'')+'>'+page+'</button>';
+      prev = page;
+    });
+
+    html += '<button type="button" class="np-page-btn np-page-next" data-page="'+(current+1)+'" aria-label="Página siguiente"'+(current>=totalPages?' disabled':'')+'>&rsaquo;</button>';
+    html += '</nav>';
+
+    const from = ((current-1)*perPage)+1;
+    const to = Math.min(totalItems, current*perPage);
+    html += '<div class="np-pagination__summary">Mostrando '+from+'–'+to+' de '+totalItems+' productos</div>';
+    $pagination.html(html).show();
+  }
+  function createStore($root){
+    const state = {
+      perPage: parseInt($root.data('perPage'),10) || 12,
+      page: 1
+    };
+
+    function buildQuery(){
+      const per = parseInt($root.data('perPage'),10);
+      if (per>0) state.perPage = per;
+      const data = {
+        action: 'norpumps_store_query',
+        nonce: NorpumpsStore.nonce,
+        per_page: state.perPage,
+        page: state.page
+      };
+      const orderby = $root.find('.np-orderby select').val();
+      if (orderby) data.orderby = orderby;
+      const search = ($root.find('.np-search').val()||'').trim();
+      if (search) data.s = search;
+      const pr = syncPriceUI($root);
+      if (pr.min!=null) data.min_price = pr.min;
+      if (pr.max!=null) data.max_price = pr.max;
+      $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
+        const group = $(this).data('group');
+        if (!group) return;
+        const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
+        const allOn = $(this).closest('.np-filter__body').find('.np-all-toggle').is(':checked');
+        if (vals.length && !allOn){ data['cat_'+group] = vals.join(','); }
+      });
+      $root.find('[data-np-query]').each(function(){
+        const key = $(this).data('npQuery');
+        if (!key) return;
+        if ($(this).is(':checkbox') || $(this).is(':radio')){
+          if ($(this).is(':radio')){
+            if ($(this).is(':checked')) data[key] = $(this).val();
+          } else {
+            const checked = $root.find('[data-np-query][data-np-query="'+key+'"][type="checkbox"]:checked').map(function(){ return this.value; }).get();
+            if (checked.length) data[key] = checked.join(',');
+          }
+        } else {
+          const value = $(this).val();
+          if (value!==null && value!==''){ data[key] = value; }
+        }
+      });
+      return data;
+    }
+
+    function applyFromURL(url){
+      const params = url.searchParams;
+      const per = parseInt(params.get('per_page'),10);
+      if (per>0){ state.perPage = per; $root.data('perPage', per); }
+      const page = parseInt(params.get('page'),10);
+      state.page = page>0 ? page : 1;
+      const orderby = params.get('orderby');
+      if (orderby){ $root.find('.np-orderby select').val(orderby); }
+      const search = params.get('s');
+      if (search!==null){ $root.find('.np-search').val(search); }
+      const pmin = params.get('min_price');
+      if (pmin!==null) $root.find('.np-range-min').val(pmin);
+      const pmax = params.get('max_price');
+      if (pmax!==null) $root.find('.np-range-max').val(pmax);
+      $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
+        const group = $(this).data('group'); if (!group) return;
+        const key = 'cat_'+group;
+        const vals = (params.get(key)||'').split(',').filter(Boolean);
+        const $body = $(this).closest('.np-filter__body');
+        const $allToggle = $body.find('.np-all-toggle');
+        if (vals.length){
+          $allToggle.prop('checked', false);
+          $(this).find('input').each(function(){ this.checked = vals.includes(this.value); });
+        } else {
+          $(this).find('input').prop('checked', false);
+          if ($allToggle.length){ $allToggle.prop('checked', true); }
+        }
+      });
+      $root.find('[data-np-query]').each(function(){
+        const key = $(this).data('npQuery');
+        if (!key) return;
+        const val = params.get(key);
+        if ($(this).is(':checkbox')){
+          const items = (val||'').split(',');
+          $(this).prop('checked', items.includes($(this).val()));
+        } else if ($(this).is(':radio')){
+          $(this).prop('checked', val!==null && val===String($(this).val()));
+        } else if (val!==null){
+          $(this).val(val);
+        } else if (!$(this).is(':radio')){
+          $(this).val('');
+        }
+      });
+      syncPriceUI($root);
+    }
+
+    function request(options){
+      const opts = options||{};
+      if (opts.resetPage){ state.page = 1; }
+      if (typeof opts.page === 'number'){ state.page = Math.max(1, opts.page); }
+      const data = buildQuery();
+      data.page = state.page;
+      const qs = toQuery(data);
+      if (opts.historyMode === 'replace' || opts.historyMode === 'push'){
+        const url = qs ? (window.location.pathname+'?'+qs) : window.location.pathname;
+        if (opts.historyMode === 'replace'){ history.replaceState({npStore:true}, '', url); }
+        else { history.pushState({npStore:true}, '', url); }
+      }
+      $root.addClass('is-loading');
+      $.post(NorpumpsStore.ajax_url, data)
+        .done(function(resp){
+          if (!resp || !resp.success) return;
+          $root.find('.js-np-grid').html(resp.data.html);
+          renderPagination($root, resp.data.pagination||{}, state);
+        })
+        .always(function(){
+          $root.removeClass('is-loading');
+        });
+    }
+
+    function init(){
+      applyFromURL(new URL(window.location.href));
+      $root.on('change', '.np-orderby select', function(){ request({resetPage:true, historyMode:'push'}); });
+      $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); });
+      $root.on('change', '.np-price__slider input[type=range]', function(){ request({resetPage:true, historyMode:'push'}); });
+      $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) request({resetPage:true, historyMode:'push'}); });
+      $root.on('change', '.np-all-toggle', function(){
+        const $body = $(this).closest('.np-filter__body');
+        $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
+        request({resetPage:true, historyMode:'push'});
+      });
+      $root.on('change', '.np-checklist input[type=checkbox]', function(){
+        const $body = $(this).closest('.np-filter__body');
+        if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
+        const anyChecked = $body.find('.np-checklist input:checked').length>0;
+        if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
+        request({resetPage:true, historyMode:'push'});
+      });
+      $root.on('change', '[data-np-query]:input', function(){
+        if ($(this).closest('.np-checklist').length) return;
+        request({resetPage:true, historyMode:'push'});
+      });
+      $root.on('submit', 'form[data-np-query-form]', function(e){ e.preventDefault(); request({resetPage:true, historyMode:'push'}); });
+      $root.on('np:filters-changed', function(){ request({resetPage:true, historyMode:'push'}); });
+      $root.on('click', '.np-page-btn', function(){
+        const $btn = $(this);
+        if ($btn.is('[disabled]') || $btn.hasClass('is-active')) return;
+        const page = parseInt($btn.data('page'),10);
+        if (page>0) request({page:page, historyMode:'push'});
+      });
+      request({historyMode:'replace'});
+    }
+
+    init();
+    return {
+      syncFromHistory: function(url){
+        applyFromURL(url);
+        request({historyMode:false});
+      }
+    };
+  }
+
+  const instances = [];
+  $('.norpumps-store').each(function(){ instances.push(createStore($(this))); });
+
+  $(window).on('popstate', function(){
+    const url = new URL(window.location.href);
+    instances.forEach(function(instance){ instance.syncFromHistory(url); });
   });
 });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -5,16 +5,18 @@ $price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>">
+<?php $per_page = max(1, intval(norpumps_array_get($atts, 'per_page', 12))); ?>
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
+      <?php $orderby = sanitize_text_field(norpumps_array_get($atts, 'order', 'menu_order title')); ?>
       <select class="np-orderby">
-        <option value="menu_order title"><?php esc_html_e('Predeterminado','norpumps'); ?></option>
-        <option value="price"><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
-        <option value="price-desc"><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
-        <option value="date"><?php esc_html_e('Novedades','norpumps'); ?></option>
-        <option value="popularity"><?php esc_html_e('Popularidad','norpumps'); ?></option>
+        <option value="menu_order title" <?php selected($orderby, 'menu_order title'); ?>><?php esc_html_e('Predeterminado','norpumps'); ?></option>
+        <option value="price" <?php selected($orderby, 'price'); ?>><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
+        <option value="price-desc" <?php selected($orderby, 'price-desc'); ?>><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
+        <option value="date" <?php selected($orderby, 'date'); ?>><?php esc_html_e('Novedades','norpumps'); ?></option>
+        <option value="popularity" <?php selected($orderby, 'popularity'); ?>><?php esc_html_e('Popularidad','norpumps'); ?></option>
       </select>
     </div>
     <div class="norpumps-store__search">


### PR DESCRIPTION
## Summary
- add pagination metadata handling in the store module and expose per-page/order defaults to the template
- rebuild the store front-end script with stateful, history-aware pagination that keeps active filters across navigation
- refresh pagination styles for front-end and admin views to present an accessible, modern control

## Testing
- php -l modules/store/module.php

------
https://chatgpt.com/codex/tasks/task_e_68efe8b17d448330acdda435523fc398