### PR TITLE
Add resilient pagination to store module

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -31,7 +31,17 @@
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
 .np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
-.np-pagination{ margin:20px 0; text-align:center; }
+.norpumps-store.is-loading .np-grid{ position:relative; opacity:.5; }
+.norpumps-store.is-loading .np-grid::after{ content:'Cargando…'; position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:14px; color:#0f5b62; background:rgba(255,255,255,0.65); border-radius:12px; }
+.np-pagination{ margin:24px 0 0; text-align:center; }
+.np-pagination__nav{ display:inline-block; background:#fff; border:1px solid var(--np-border); border-radius:999px; padding:6px 10px; box-shadow:0 6px 16px rgba(15,91,98,0.08); }
+.np-pagination__list{ list-style:none; display:flex; align-items:center; gap:4px; margin:0; padding:0; }
+.np-pagination__item{ }
+.np-pagination__item.is-active .np-pagination__link{ background:var(--np-accent); color:#fff; box-shadow:0 4px 10px rgba(15,91,98,0.25); }
+.np-pagination__item.is-disabled .np-pagination__link{ opacity:.35; pointer-events:none; }
+.np-pagination__ellipsis{ padding:6px 8px; color:#6a7a83; }
+.np-pagination__link{ display:inline-flex; align-items:center; justify-content:center; min-width:36px; min-height:36px; padding:0 10px; border-radius:999px; color:var(--np-text); border:1px solid transparent; font-weight:600; transition:all .2s ease; }
+.np-pagination__link:hover{ border-color:var(--np-accent); color:var(--np-accent); }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,4 +1,10 @@
 jQuery(function($){
+  const ORDER_DIRECTIONS = {
+    'price':'ASC',
+    'price-desc':'DESC',
+    'date':'DESC',
+    'popularity':'DESC'
+  };
   function clamp(v,a,b){ v=parseFloat(v||0); return Math.min(Math.max(v,a), b); }
   function syncPriceUI($root){
     const $wrap = $root.find('.np-price__slider'); if (!$wrap.length) return {};
@@ -9,9 +15,23 @@ jQuery(function($){
     $root.find('.np-price-min').text(vmin); $root.find('.np-price-max').text(vmax);
     return {min:vmin, max:vmax};
   }
+  function getPerPage($root){
+    return parseInt($root.data('per-page'), 10) || 12;
+  }
+  function getDefaultPerPage($root){
+    return parseInt($root.data('default-per-page'), 10) || getPerPage($root);
+  }
+  function getCurrentPage($root){
+    return parseInt($root.data('current-page'), 10) || 1;
+  }
   function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
-    data.orderby = $root.find('.np-orderby select').val();
+    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
+    data.per_page = getPerPage($root);
+    data.page = getCurrentPage($root);
+    const orderby = $root.find('.np-orderby select').val();
+    data.orderby = orderby;
+    const orderDir = ORDER_DIRECTIONS[orderby];
+    if (orderDir){ data.order = orderDir; }
     const q = $root.find('.np-search').val(); if (q) data.s = q;
     const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
@@ -22,39 +42,62 @@ jQuery(function($){
     });
     return data;
   }
-  function toQuery(obj){
+  function toQuery($root, obj){
     const p = new URLSearchParams();
-    Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
+    const defaultPer = getDefaultPerPage($root);
+    Object.keys(obj).forEach(k=>{
+      if (['action','nonce'].includes(k)) return;
+      if (k === 'page' && parseInt(obj[k], 10) <= 1) return;
+      if (k === 'per_page' && parseInt(obj[k], 10) === defaultPer) return;
+      if (obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]);
+    });
     return p.toString();
   }
-  function load($root){
+  function load($root, page){
+    if (typeof page !== 'undefined'){ $root.data('current-page', Math.max(1, parseInt(page, 10) || 1)); }
     const data = buildQuery($root);
-    const qs = toQuery(data);
+    const qs = toQuery($root, data);
     history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
+    $root.addClass('is-loading');
     $.post(NorpumpsStore.ajax_url, data, function(resp){
       if (!resp || !resp.success) return;
       $root.find('.js-np-grid').html(resp.data.html);
+      $root.find('.js-np-pagination').html(resp.data.pagination_html || '');
+      if (resp.data.page){ $root.data('current-page', resp.data.page); }
+      if (resp.data.args && resp.data.args.limit){ $root.data('per-page', parseInt(resp.data.args.limit, 10)); }
+    }).always(function(){
+      $root.removeClass('is-loading');
     });
   }
+  function resetToFirstPage($root){ $root.data('current-page', 1); }
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
-      load($root);
+      resetToFirstPage($root);
+      load($root, 1);
     });
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
       const $body = $(this).closest('.np-filter__body');
       if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
       const anyChecked = $body.find('.np-checklist input:checked').length>0;
       if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
-      load($root);
+      resetToFirstPage($root);
+      load($root, 1);
     });
   }
   $('.norpumps-store').each(function(){
     const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
+    $root.on('change', '.np-orderby select', function(){ resetToFirstPage($root); load($root, 1); });
+    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ resetToFirstPage($root); load($root, 1); });
+    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13){ resetToFirstPage($root); load($root, 1); } });
+    $root.on('click', '.js-np-page', function(e){
+      e.preventDefault();
+      const $item = $(this).closest('.np-pagination__item');
+      if ($item.hasClass('is-disabled') || $item.hasClass('is-active')) return;
+      const page = parseInt($(this).data('page'), 10);
+      if (page){ load($root, page); }
+    });
     bindAllToggle($root);
     const url = new URL(window.location.href);
     const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
@@ -69,6 +112,16 @@ jQuery(function($){
         $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });
       }
     });
-    load($root);
+    const queryOrder = url.searchParams.get('orderby');
+    if (queryOrder && $root.find('.np-orderby select option[value="'+queryOrder+'"]').length){
+      $root.find('.np-orderby select').val(queryOrder);
+    }
+    const querySearch = url.searchParams.get('s');
+    if (querySearch){ $root.find('.np-search').val(querySearch); }
+    const queryPer = parseInt(url.searchParams.get('per_page'), 10);
+    if (queryPer){ $root.data('per-page', queryPer); }
+    const queryPage = parseInt(url.searchParams.get('page'), 10);
+    if (queryPage){ $root.data('current-page', queryPage); }
+    load($root, getCurrentPage($root));
   });
 });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -5,7 +5,7 @@ $price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="1">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>


### PR DESCRIPTION
## Summary
- add WooCommerce pagination support and expose metadata from the `norpumps_store` Ajax endpoint
- persist filters, sorting, and search when navigating pages via a refreshed front-end controller
- style the pagination controls and add a subtle loading indicator for product grids

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f00866e7dc8330975df9c05bf3cc1d