### PR TITLE
Enhance store pagination controls

### DIFF
--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,24 +1,31 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$price_min = isset($atts['price_min']) ? floatval($atts['price_min']) : 0;
-$price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
+$default_min = isset($default_min_price) ? floatval($default_min_price) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
+$default_max = isset($default_max_price) ? floatval($default_max_price) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
+$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $default_min;
+$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $default_max;
+$current_per_page = isset($requested_per_page) ? intval($requested_per_page) : (isset($per_page) ? intval($per_page) : 12);
+$current_page = isset($requested_page) ? intval($requested_page) : 1;
+$default_page_attr = isset($default_page) ? intval($default_page) : 1;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
+$search_value = isset($search_query) ? $search_query : '';
+$orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="1">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($default_min); ?>" data-default-max-price="<?php echo esc_attr($default_max); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
       <select class="np-orderby">
-        <option value="menu_order title"><?php esc_html_e('Predeterminado','norpumps'); ?></option>
-        <option value="price"><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
-        <option value="price-desc"><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
-        <option value="date"><?php esc_html_e('Novedades','norpumps'); ?></option>
-        <option value="popularity"><?php esc_html_e('Popularidad','norpumps'); ?></option>
+        <option value="menu_order title" <?php selected($orderby_value, 'menu_order title'); ?>><?php esc_html_e('Predeterminado','norpumps'); ?></option>
+        <option value="price" <?php selected($orderby_value, 'price'); ?>><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
+        <option value="price-desc" <?php selected($orderby_value, 'price-desc'); ?>><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
+        <option value="date" <?php selected($orderby_value, 'date'); ?>><?php esc_html_e('Novedades','norpumps'); ?></option>
+        <option value="popularity" <?php selected($orderby_value, 'popularity'); ?>><?php esc_html_e('Popularidad','norpumps'); ?></option>
       </select>
     </div>
     <div class="norpumps-store__search">
-      <input type="search" class="np-search" placeholder="<?php esc_attr_e('Buscar productos…','norpumps'); ?>">
+      <input type="search" class="np-search" value="<?php echo esc_attr($search_value); ?>" placeholder="<?php esc_attr_e('Buscar productos…','norpumps'); ?>">
     </div>
   </div>
 
@@ -29,14 +36,14 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
         <div class="np-filter__body">
           <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($price_min); ?>" data-max="<?php echo esc_attr($price_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
+            <div class="np-price__slider" data-min="<?php echo esc_attr($default_min); ?>" data-max="<?php echo esc_attr($default_max); ?>">
+              <input type="range" class="np-range-min" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_min); ?>">
+              <input type="range" class="np-range-max" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_max); ?>">
             </div>
             <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($price_min); ?></span>
+              <span class="np-price-min"><?php echo esc_html($current_min); ?></span>
               <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($price_max); ?></span>
+              <span class="np-price-max"><?php echo esc_html($current_max); ?></span>
             </div>
           </div>
         </div>

--- a/norpumps.php
+++ b/norpumps.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * Plugin Name: NorPumps Suite
- * Description: v1.2.1 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
- * Version: 1.2.1
+ * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
+ * Version: 1.2.2
  * Author: Alfonso (fiverr)
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: norpumps
  */
 if (!defined('ABSPATH')) { exit; }
-define('NORPUMPS_VERSION', '1.2.1');
+define('NORPUMPS_VERSION', '1.2.2');
 define('NORPUMPS_PATH', plugin_dir_path(__FILE__));
 define('NORPUMPS_URL', plugin_dir_url(__FILE__));
 spl_autoload_register(function($class){


### PR DESCRIPTION
## Summary
- allow the store shortcode to configure initial page size and page number, updating the generator UI accordingly
- respect incoming query parameters, keep the URL clean of defaults, and smooth-scroll after AJAX updates while keeping history in sync
- harden WooCommerce queries so pagination metadata is calculated reliably and bump the plugin version for cache busting

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f0140bde448330983b71dfa7b89a26