### PR TITLE
Fix store price filter defaults and slider styling

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,8 +13,10 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
+.np-price__slider{ position:relative; height:30px; --np-range-track:#d4e6e7; --np-range-fill:#083640; --np-min:0%; --np-max:100%; }
+.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-track); }
+.np-price__slider::after{ content:""; position:absolute; left:var(--np-min); width:calc(var(--np-max) - var(--np-min)); top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-fill); }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; z-index:1; }
 .np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
 .np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,8 +13,10 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
+.np-price__slider{ position:relative; height:30px; --np-range-track:#d4e6e7; --np-range-fill:#083640; --np-min:0%; --np-max:100%; }
+.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-track); }
+.np-price__slider::after{ content:""; position:absolute; left:var(--np-min); width:calc(var(--np-max) - var(--np-min)); top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-fill); }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; z-index:1; }
 .np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
 .np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
 .np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -54,16 +54,30 @@ jQuery(function($){
   function syncPriceUI($root){
     const $wrap = $root.find('.np-price__slider');
     if (!$wrap.length) return {};
-    const sliderMin = parseFloat($wrap.data('min'));
-    const sliderMax = parseFloat($wrap.data('max'));
+    const sliderMinData = parseFloat($wrap.data('min'));
+    const sliderMaxData = parseFloat($wrap.data('max'));
     const $min = $wrap.find('.np-range-min');
     const $max = $wrap.find('.np-range-max');
+    const minAttr = parseFloat($min.attr('min'));
+    const maxAttr = parseFloat($max.attr('max'));
+    const sliderMin = isFiniteNumber(sliderMinData) ? sliderMinData : (isFiniteNumber(minAttr) ? minAttr : 0);
+    const sliderMax = isFiniteNumber(sliderMaxData) ? sliderMaxData : (isFiniteNumber(maxAttr) ? maxAttr : sliderMin);
     let vmin = clamp($min.val(), sliderMin, sliderMax);
     let vmax = clamp($max.val(), sliderMin, sliderMax);
     if (vmin > vmax){ const tmp = vmin; vmin = vmax; vmax = tmp; }
     $min.val(vmin); $max.val(vmax);
     $root.find('.np-price-min').text(vmin);
     $root.find('.np-price-max').text(vmax);
+    if (isFiniteNumber(sliderMax) && isFiniteNumber(sliderMin) && sliderMax > sliderMin){
+      const range = sliderMax - sliderMin;
+      const pctMin = Math.min(100, Math.max(0, ((vmin - sliderMin) / range) * 100));
+      const pctMax = Math.min(100, Math.max(0, ((vmax - sliderMin) / range) * 100));
+      $wrap.css('--np-min', pctMin + '%');
+      $wrap.css('--np-max', pctMax + '%');
+    } else {
+      $wrap.css('--np-min', '0%');
+      $wrap.css('--np-max', '100%');
+    }
     return {min:vmin, max:vmax};
   }
   function buildQuery($root){


### PR DESCRIPTION
## Summary
- derive price filter defaults from current product data when shortcode attributes are omitted while keeping shortcode overrides intact
- clamp and round requested price values so URL state and AJAX queries stay within the resolved bounds
- restyle the price slider track to use the brand accent color and update the frontend script to show the active range visually

## Testing
- php -l modules/store/module.php

------
https://chatgpt.com/codex/tasks/task_e_68f02381e37483309e956a37f0d5b0a9