### PR TITLE
Fix price filter bounds and redesign slider

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,13 +13,22 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; --np-range-track:#d4e6e7; --np-range-fill:#083640; --np-min:0%; --np-max:100%; }
-.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-track); }
-.np-price__slider::after{ content:""; position:absolute; left:var(--np-min); width:calc(var(--np-max) - var(--np-min)); top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-fill); }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; z-index:1; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
+.np-price{ background:linear-gradient(180deg,#f6fbfb 0%,#e8f1f2 100%); border:1px solid rgba(8,54,64,0.12); border-radius:20px; padding:18px 20px 20px; box-shadow:0 10px 26px rgba(8,54,64,0.08); display:flex; flex-direction:column; gap:16px; }
+.np-price__rail{ position:relative; height:42px; border-radius:999px; background:rgba(8,54,64,0.06); box-shadow:inset 0 0 0 1px rgba(8,54,64,0.12); overflow:hidden; }
+.np-price__slider{ position:absolute; inset:0; --np-range-track:rgba(8,54,64,0.08); --np-range-fill:#083640; --np-min:0%; --np-max:100%; }
+.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:12px; border-radius:999px; margin:0 12px; background:var(--np-range-track); box-shadow:inset 0 1px 2px rgba(255,255,255,0.6); }
+.np-price__slider::after{ content:""; position:absolute; top:50%; transform:translateY(-50%); height:12px; border-radius:999px; left:calc(var(--np-min) + 12px); right:calc((100% - var(--np-max)) + 12px); background:var(--np-range-fill); box-shadow:0 8px 18px rgba(8,54,64,0.25); }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:42px; z-index:1; }
+.np-price__slider input[type=range]:focus{ outline:none; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:22px; height:22px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); transition:transform .15s ease, box-shadow .15s ease; }
+.np-price__slider input::-webkit-slider-thumb:active{ transform:scale(1.05); box-shadow:0 6px 16px rgba(8,54,64,0.45); }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:22px; height:22px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); transition:transform .15s ease, box-shadow .15s ease; }
+.np-price__slider input::-moz-range-thumb:active{ transform:scale(1.05); box-shadow:0 6px 16px rgba(8,54,64,0.45); }
+.np-price__labels{ display:flex; align-items:center; justify-content:space-between; gap:16px; font-size:13px; color:#083640; font-weight:600; }
+.np-price__label{ display:flex; flex-direction:column; gap:4px; }
+.np-price__label-caption{ font-size:11px; letter-spacing:.12em; text-transform:uppercase; color:rgba(8,54,64,0.65); }
+.np-price__label-value{ display:inline-flex; align-items:center; gap:6px; padding:6px 14px; border-radius:999px; background:rgba(8,54,64,0.08); box-shadow:inset 0 0 0 1px rgba(8,54,64,0.08); font-weight:700; color:#083640; }
+.np-price__label-separator{ letter-spacing:.35em; font-size:11px; color:rgba(8,54,64,0.45); font-weight:700; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,13 +13,22 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; --np-range-track:#d4e6e7; --np-range-fill:#083640; --np-min:0%; --np-max:100%; }
-.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-track); }
-.np-price__slider::after{ content:""; position:absolute; left:var(--np-min); width:calc(var(--np-max) - var(--np-min)); top:50%; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-range-fill); }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; z-index:1; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
+.np-price{ background:linear-gradient(180deg,#f6fbfb 0%,#e8f1f2 100%); border:1px solid rgba(8,54,64,0.12); border-radius:20px; padding:18px 20px 20px; box-shadow:0 10px 26px rgba(8,54,64,0.08); display:flex; flex-direction:column; gap:16px; }
+.np-price__rail{ position:relative; height:42px; border-radius:999px; background:rgba(8,54,64,0.06); box-shadow:inset 0 0 0 1px rgba(8,54,64,0.12); overflow:hidden; }
+.np-price__slider{ position:absolute; inset:0; --np-range-track:rgba(8,54,64,0.08); --np-range-fill:#083640; --np-min:0%; --np-max:100%; }
+.np-price__slider::before{ content:""; position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:12px; border-radius:999px; margin:0 12px; background:var(--np-range-track); box-shadow:inset 0 1px 2px rgba(255,255,255,0.6); }
+.np-price__slider::after{ content:""; position:absolute; top:50%; transform:translateY(-50%); height:12px; border-radius:999px; left:calc(var(--np-min) + 12px); right:calc((100% - var(--np-max)) + 12px); background:var(--np-range-fill); box-shadow:0 8px 18px rgba(8,54,64,0.25); }
+.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:42px; z-index:1; }
+.np-price__slider input[type=range]:focus{ outline:none; }
+.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:22px; height:22px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); transition:transform .15s ease, box-shadow .15s ease; }
+.np-price__slider input::-webkit-slider-thumb:active{ transform:scale(1.05); box-shadow:0 6px 16px rgba(8,54,64,0.45); }
+.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:22px; height:22px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); transition:transform .15s ease, box-shadow .15s ease; }
+.np-price__slider input::-moz-range-thumb:active{ transform:scale(1.05); box-shadow:0 6px 16px rgba(8,54,64,0.45); }
+.np-price__labels{ display:flex; align-items:center; justify-content:space-between; gap:16px; font-size:13px; color:#083640; font-weight:600; }
+.np-price__label{ display:flex; flex-direction:column; gap:4px; }
+.np-price__label-caption{ font-size:11px; letter-spacing:.12em; text-transform:uppercase; color:rgba(8,54,64,0.65); }
+.np-price__label-value{ display:inline-flex; align-items:center; gap:6px; padding:6px 14px; border-radius:999px; background:rgba(8,54,64,0.08); box-shadow:inset 0 0 0 1px rgba(8,54,64,0.08); font-weight:700; color:#083640; }
+.np-price__label-separator{ letter-spacing:.35em; font-size:11px; color:rgba(8,54,64,0.45); font-weight:700; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,9 +1,13 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$default_min = isset($default_min_price) ? floatval($default_min_price) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
-$default_max = isset($default_max_price) ? floatval($default_max_price) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
-$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $default_min;
-$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $default_max;
+$slider_min = isset($default_min_price) ? floatval($default_min_price) : 0;
+$slider_max = isset($default_max_price) ? floatval($default_max_price) : $slider_min;
+$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $slider_min;
+$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $slider_max;
+$available_min = isset($available_min_price) ? $available_min_price : null;
+$available_max = isset($available_max_price) ? $available_max_price : null;
+$price_floor_value = (isset($price_min_defined) && $price_min_defined && isset($attribute_min_price)) ? floatval($attribute_min_price) : $slider_min;
+$price_ceiling_value = (isset($price_max_defined) && $price_max_defined && isset($attribute_max_price)) ? floatval($attribute_max_price) : $slider_max;
 $current_per_page = isset($requested_per_page) ? intval($requested_per_page) : (isset($per_page) ? intval($per_page) : 12);
 $current_page = isset($requested_page) ? intval($requested_page) : 1;
 $default_page_attr = isset($default_page) ? intval($default_page) : 1;
@@ -12,7 +16,7 @@ $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($default_min); ?>" data-default-max-price="<?php echo esc_attr($default_max); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($slider_min); ?>" data-default-max-price="<?php echo esc_attr($slider_max); ?>" data-price-floor="<?php echo esc_attr($price_floor_value); ?>" data-price-ceiling="<?php echo esc_attr($price_ceiling_value); ?>" data-price-floor-defined="<?php echo !empty($price_min_defined) ? '1' : '0'; ?>" data-price-ceiling-defined="<?php echo !empty($price_max_defined) ? '1' : '0'; ?>" data-price-available-min="<?php echo $available_min !== null ? esc_attr($available_min) : ''; ?>" data-price-available-max="<?php echo $available_max !== null ? esc_attr($available_max) : ''; ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -36,14 +40,22 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
         <div class="np-filter__body">
           <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($default_min); ?>" data-max="<?php echo esc_attr($default_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_max); ?>">
+            <div class="np-price__rail" data-min="<?php echo esc_attr($slider_min); ?>" data-max="<?php echo esc_attr($slider_max); ?>">
+              <div class="np-price__slider" data-min="<?php echo esc_attr($slider_min); ?>" data-max="<?php echo esc_attr($slider_max); ?>">
+                <input type="range" class="np-range-min" min="<?php echo esc_attr($slider_min); ?>" max="<?php echo esc_attr($slider_max); ?>" value="<?php echo esc_attr($current_min); ?>">
+                <input type="range" class="np-range-max" min="<?php echo esc_attr($slider_min); ?>" max="<?php echo esc_attr($slider_max); ?>" value="<?php echo esc_attr($current_max); ?>">
+              </div>
             </div>
             <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($current_min); ?></span>
-              <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($current_max); ?></span>
+              <div class="np-price__label">
+                <span class="np-price__label-caption"><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                <span class="np-price__label-value"><span class="np-price-min"><?php echo esc_html($current_min); ?></span></span>
+              </div>
+              <span class="np-price__label-separator">—</span>
+              <div class="np-price__label">
+                <span class="np-price__label-caption"><?php esc_html_e('Máximo','norpumps'); ?></span>
+                <span class="np-price__label-value"><span class="np-price-max"><?php echo esc_html($current_max); ?></span></span>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Resolve price limits from the active WooCommerce query and return them in AJAX responses so category, pagination, and URL filters stay aligned.
- Update the shortcode template and store.js logic to clamp slider values, refresh defaults from the server, and push range changes into the URL.
- Restyle the price slider with a #083640 accent for both storefront and admin previews so the range track is visible and polished.

## Testing
- php -l modules/store/module.php

------
https://chatgpt.com/codex/tasks/task_e_68f027bc7538833087eb9470b946188d