### PR TITLE
Remove price filter from NorPumps store module

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,11 +13,6 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,11 +13,6 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,18 +1,11 @@
 jQuery(function($){
   const ORDER_DIRECTIONS = {
-    'price':'ASC',
-    'price-desc':'DESC',
     'date':'DESC',
     'popularity':'DESC'
   };
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
-  function clamp(value, min, max){
-    value = parseFloat(value || 0);
-    if (!isFiniteNumber(value)) value = min;
-    return Math.min(Math.max(value, min), max);
-  }
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
     return isFiniteNumber(val) && val > 0 ? val : 12;
@@ -43,29 +36,6 @@ jQuery(function($){
     setCurrentPage($root, fallback);
     return fallback;
   }
-  function getDefaultMinPrice($root){
-    const val = parseFloat($root.data('defaultMinPrice'));
-    return isFiniteNumber(val) ? val : null;
-  }
-  function getDefaultMaxPrice($root){
-    const val = parseFloat($root.data('defaultMaxPrice'));
-    return isFiniteNumber(val) ? val : null;
-  }
-  function syncPriceUI($root){
-    const $wrap = $root.find('.np-price__slider');
-    if (!$wrap.length) return {};
-    const sliderMin = parseFloat($wrap.data('min'));
-    const sliderMax = parseFloat($wrap.data('max'));
-    const $min = $wrap.find('.np-range-min');
-    const $max = $wrap.find('.np-range-max');
-    let vmin = clamp($min.val(), sliderMin, sliderMax);
-    let vmax = clamp($max.val(), sliderMin, sliderMax);
-    if (vmin > vmax){ const tmp = vmin; vmin = vmax; vmax = tmp; }
-    $min.val(vmin); $max.val(vmax);
-    $root.find('.np-price-min').text(vmin);
-    $root.find('.np-price-max').text(vmax);
-    return {min:vmin, max:vmax};
-  }
   function buildQuery($root){
     const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
     data.per_page = getPerPage($root);
@@ -76,9 +46,6 @@ jQuery(function($){
     if (orderDir){ data.order = orderDir; }
     const search = $root.find('.np-search').val();
     if (search){ data.s = search; }
-    const price = syncPriceUI($root);
-    if (price.min != null) data.min_price = price.min;
-    if (price.max != null) data.max_price = price.max;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
@@ -93,15 +60,11 @@ jQuery(function($){
     const params = new URLSearchParams();
     const defaultPer = getDefaultPerPage($root);
     const defaultPage = getDefaultPage($root);
-    const defaultMin = getDefaultMinPrice($root);
-    const defaultMax = getDefaultMaxPrice($root);
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
-      if (key === 'min_price' && defaultMin !== null && parseFloat(obj[key]) === defaultMin) return;
-      if (key === 'max_price' && defaultMax !== null && parseFloat(obj[key]) === defaultMax) return;
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -156,8 +119,6 @@ jQuery(function($){
     setCurrentPage($root, getCurrentPage($root));
 
     $root.on('change', '.np-orderby select', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); })
-         .on('change', '.np-price__slider input[type=range]', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
     $root.on('keyup', '.np-search', function(e){ if (e.keyCode === 13){ resetToFirstPage($root); load($root, 1, {scroll:true}); } });
     $root.on('click', '.js-np-page', function(e){
       e.preventDefault();
@@ -170,12 +131,6 @@ jQuery(function($){
     bindAllToggle($root);
 
     const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price');
-    const pmax = url.searchParams.get('max_price');
-    if (pmin != null){ $root.find('.np-range-min').val(pmin); }
-    if (pmax != null){ $root.find('.np-range-max').val(pmax); }
-    syncPriceUI($root);
-
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       if (!group) return;

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,9 +1,5 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$default_min = isset($default_min_price) ? floatval($default_min_price) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
-$default_max = isset($default_max_price) ? floatval($default_max_price) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
-$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $default_min;
-$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $default_max;
 $current_per_page = isset($requested_per_page) ? intval($requested_per_page) : (isset($per_page) ? intval($per_page) : 12);
 $current_page = isset($requested_page) ? intval($requested_page) : 1;
 $default_page_attr = isset($default_page) ? intval($default_page) : 1;
@@ -12,14 +8,12 @@ $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($default_min); ?>" data-default-max-price="<?php echo esc_attr($default_max); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
       <select class="np-orderby">
         <option value="menu_order title" <?php selected($orderby_value, 'menu_order title'); ?>><?php esc_html_e('Predeterminado','norpumps'); ?></option>
-        <option value="price" <?php selected($orderby_value, 'price'); ?>><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
-        <option value="price-desc" <?php selected($orderby_value, 'price-desc'); ?>><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
         <option value="date" <?php selected($orderby_value, 'date'); ?>><?php esc_html_e('Novedades','norpumps'); ?></option>
         <option value="popularity" <?php selected($orderby_value, 'popularity'); ?>><?php esc_html_e('Popularidad','norpumps'); ?></option>
       </select>
@@ -31,25 +25,6 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
-      <?php if (in_array('price',$filters_arr)): ?>
-      <div class="np-filter">
-        <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
-        <div class="np-filter__body">
-          <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($default_min); ?>" data-max="<?php echo esc_attr($default_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_max); ?>">
-            </div>
-            <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($current_min); ?></span>
-              <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($current_max); ?></span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <?php endif; ?>
-
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/norpumps.php
+++ b/norpumps.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: NorPumps Suite
- * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
+ * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
  * Version: 1.2.2
  * Author: Alfonso (fiverr)
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- drop the price filter controls from the store generator and shortcode defaults
- remove price-related handling from the store template, JavaScript, and styles
- update the plugin description to stop referencing the price slider

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f02da01cd0833094035085f877e039