### PR TITLE
Add price range filter slider to NorPumps store module

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -30,6 +30,8 @@
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }
 .norpumps-admin .np-row label{ min-width:260px; font-weight:700; }
+.norpumps-admin .np-row.is-disabled{ opacity:.55; }
+.norpumps-admin .np-row.is-disabled input{ background:#f3f6f8; }
 .norpumps-admin .np-chip{ display:inline-flex; align-items:center; gap:6px; background:#eef7f8; padding:6px 10px; border-radius:999px; margin-right:8px; }
 .norpumps-admin .np-group{ display:flex; gap:10px; align-items:center; margin:8px 0; }
 .norpumps-admin .np-group input{ padding:6px 8px; }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,6 +9,21 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:14px; }
+.np-price-range{ display:flex; flex-direction:column; gap:12px; }
+.np-price-range__slider{ position:relative; height:36px; display:flex; align-items:center; }
+.np-price-range__track{ --min:0%; --max:100%; position:absolute; left:0; right:0; top:50%; height:6px; transform:translateY(-50%); border-radius:999px; background:linear-gradient(90deg,#dfe7ea 0%,#dfe7ea var(--min),#083640 var(--min),#083640 var(--max),#dfe7ea var(--max),#dfe7ea 100%); }
+.np-price-range__input{ position:absolute; left:0; right:0; top:0; bottom:0; width:100%; height:36px; margin:0; background:none; pointer-events:none; -webkit-appearance:none; appearance:none; }
+.np-price-range__input:focus{ outline:none; }
+.np-price-range__input::-webkit-slider-thumb{ pointer-events:auto; -webkit-appearance:none; appearance:none; width:20px; height:20px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 3px 10px rgba(8,54,64,0.25); cursor:pointer; transition:transform .15s ease; }
+.np-price-range__input::-webkit-slider-thumb:hover{ transform:scale(1.05); }
+.np-price-range__input::-moz-range-thumb{ pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 3px 10px rgba(8,54,64,0.25); cursor:pointer; transition:transform .15s ease; }
+.np-price-range__input::-moz-range-thumb:hover{ transform:scale(1.05); }
+.np-price-range__input::-ms-thumb{ pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 3px 10px rgba(8,54,64,0.25); cursor:pointer; }
+.np-price-range__input::-webkit-slider-runnable-track{ background:transparent; }
+.np-price-range__input::-moz-range-track{ background:transparent; }
+.np-price-range__values{ display:flex; justify-content:space-between; font-weight:700; color:#083640; font-size:15px; }
+.np-price-range__hint{ font-size:12px; color:#517079; margin:0; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,6 +7,7 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_filter_enabled = in_array('price', $filters_arr, true);
 ?>
 <div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
   <div class="norpumps-store__header">
@@ -25,6 +26,25 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if ($price_filter_enabled): ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Rango de precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-base-min="<?php echo esc_attr($price_min_attr); ?>" data-base-max="<?php echo esc_attr($price_max_attr); ?>" data-current-min="<?php echo esc_attr($price_current_min); ?>" data-current-max="<?php echo esc_attr($price_current_max); ?>" data-step="<?php echo esc_attr($price_step); ?>">
+              <div class="np-price-range__slider">
+                <div class="np-price-range__track"></div>
+                <input type="range" class="np-price-range__input np-price-range__input--min" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($price_current_min); ?>" aria-label="<?php esc_attr_e('Precio mínimo','norpumps'); ?>">
+                <input type="range" class="np-price-range__input np-price-range__input--max" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($price_current_max); ?>" aria-label="<?php esc_attr_e('Precio máximo','norpumps'); ?>">
+              </div>
+              <div class="np-price-range__values">
+                <span class="np-price-value np-price-value--min"><?php echo esc_html($price_display_min); ?></span>
+                <span class="np-price-value np-price-value--max"><?php echo esc_html($price_display_max); ?></span>
+              </div>
+              <p class="np-price-range__hint"><?php esc_html_e('Arrastra los puntos o toca para ajustar el rango.','norpumps'); ?></p>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/norpumps.php
+++ b/norpumps.php
@@ -57,9 +57,16 @@ class NorPumps_App {
     public function front_assets(){
         wp_enqueue_style('norpumps-store', NORPUMPS_URL.'assets/css/store.css',[],NORPUMPS_VERSION);
         wp_enqueue_script('norpumps-store', NORPUMPS_URL.'assets/js/store.js',['jquery'],NORPUMPS_VERSION,true);
+        $currency_symbol = function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$';
+        $currency_code = function_exists('get_woocommerce_currency') ? get_woocommerce_currency() : 'USD';
+        $price_decimals = function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : 0;
         wp_localize_script('norpumps-store','NorpumpsStore',[
             'ajax_url'=>admin_url('admin-ajax.php'),
             'nonce'=>wp_create_nonce('norpumps_store'),
+            'currency_symbol'=>$currency_symbol,
+            'currency'=>$currency_code,
+            'price_decimals'=>$price_decimals,
+            'locale'=>get_locale(),
         ]);
     }
     public function admin_assets($hook){


### PR DESCRIPTION
## Summary
- add shortcode options and admin generator controls for enabling a price range filter
- render a dual-handle price slider in the store filters and style it with the requested accent color
- update frontend logic to sync the slider with AJAX queries, friendly URLs, and WooCommerce min/max price filtering
- expose WooCommerce currency metadata to JavaScript for consistent formatting

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php
- php -l norpumps.php

------
https://chatgpt.com/codex/tasks/task_e_68f03123e0608330ab509621a9cfda4e