### PR TITLE
Add price range filter support to store shortcode

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,11 +13,6 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,10 +9,30 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.np-filter--price .np-filter__body{ padding:16px 18px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
+.np-price-range{ display:flex; flex-direction:column; gap:12px; }
+.np-price-range__values{ display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
+.np-price-range__pill{ background:#f0f7f8; border:1px solid #d2e3e6; border-radius:999px; padding:8px 18px; min-width:140px; display:flex; flex-direction:column; text-align:center; color:#083640; box-shadow:0 4px 12px rgba(8,54,64,0.08); }
+.np-price-range__label{ font-size:11px; text-transform:uppercase; letter-spacing:.08em; font-weight:700; opacity:.8; }
+.np-price-range__value{ font-size:18px; font-weight:800; margin-top:4px; letter-spacing:.02em; }
+.np-price-range__inputs{ position:relative; height:36px; margin-top:6px; }
+.np-price-range__inputs::before{ content:""; position:absolute; top:50%; left:0; right:0; height:8px; border-radius:999px; background:#dbe6ea; transform:translateY(-50%); }
+.np-price-range__progress{ position:absolute; top:50%; height:8px; border-radius:999px; transform:translateY(-50%); background:#083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); }
+.np-price-range__input{ position:absolute; left:0; top:0; width:100%; height:36px; margin:0; background:transparent; pointer-events:none; -webkit-appearance:none; appearance:none; }
+.np-price-range__input:first-of-type{ z-index:3; }
+.np-price-range__input:last-of-type{ z-index:2; }
+.np-price-range__input::-webkit-slider-thumb{ pointer-events:auto; -webkit-appearance:none; appearance:none; width:20px; height:20px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 0 0 2px rgba(8,54,64,0.25); cursor:pointer; }
+.np-price-range__input::-webkit-slider-runnable-track{ -webkit-appearance:none; background:transparent; }
+.np-price-range__input::-moz-range-thumb{ pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 0 0 2px rgba(8,54,64,0.25); cursor:pointer; }
+.np-price-range__input::-moz-range-track{ background:transparent; border:none; }
+.np-price-range__input::-ms-thumb{ pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#083640; border:3px solid #fff; box-shadow:0 0 0 2px rgba(8,54,64,0.25); cursor:pointer; }
+.np-price-range__input::-ms-track{ background:transparent; border-color:transparent; color:transparent; }
+.np-price-range__input::-ms-fill-lower, .np-price-range__input::-ms-fill-upper{ background:transparent; }
+.np-price-range__input:focus{ outline:none; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }
@@ -41,6 +61,9 @@
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }
 .norpumps-admin .np-row label{ min-width:260px; font-weight:700; }
+.norpumps-admin .np-row--price{ align-items:flex-start; flex-wrap:wrap; }
+.norpumps-admin .np-row--price input{ max-width:140px; }
+.norpumps-admin .np-row--price .help{ font-size:12px; color:#5c6c74; }
 .norpumps-admin .np-chip{ display:inline-flex; align-items:center; gap:6px; background:#eef7f8; padding:6px 10px; border-radius:999px; margin-right:8px; }
 .norpumps-admin .np-group{ display:flex; gap:10px; align-items:center; margin:8px 0; }
 .norpumps-admin .np-group input{ padding:6px 8px; }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,11 +13,6 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,18 +1,11 @@
 jQuery(function($){
   const ORDER_DIRECTIONS = {
-    'price':'ASC',
-    'price-desc':'DESC',
     'date':'DESC',
     'popularity':'DESC'
   };
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
-  function clamp(value, min, max){
-    value = parseFloat(value || 0);
-    if (!isFiniteNumber(value)) value = min;
-    return Math.min(Math.max(value, min), max);
-  }
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
     return isFiniteNumber(val) && val > 0 ? val : 12;
@@ -43,29 +36,6 @@ jQuery(function($){
     setCurrentPage($root, fallback);
     return fallback;
   }
-  function getDefaultMinPrice($root){
-    const val = parseFloat($root.data('defaultMinPrice'));
-    return isFiniteNumber(val) ? val : null;
-  }
-  function getDefaultMaxPrice($root){
-    const val = parseFloat($root.data('defaultMaxPrice'));
-    return isFiniteNumber(val) ? val : null;
-  }
-  function syncPriceUI($root){
-    const $wrap = $root.find('.np-price__slider');
-    if (!$wrap.length) return {};
-    const sliderMin = parseFloat($wrap.data('min'));
-    const sliderMax = parseFloat($wrap.data('max'));
-    const $min = $wrap.find('.np-range-min');
-    const $max = $wrap.find('.np-range-max');
-    let vmin = clamp($min.val(), sliderMin, sliderMax);
-    let vmax = clamp($max.val(), sliderMin, sliderMax);
-    if (vmin > vmax){ const tmp = vmin; vmin = vmax; vmax = tmp; }
-    $min.val(vmin); $max.val(vmax);
-    $root.find('.np-price-min').text(vmin);
-    $root.find('.np-price-max').text(vmax);
-    return {min:vmin, max:vmax};
-  }
   function buildQuery($root){
     const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
     data.per_page = getPerPage($root);
@@ -76,9 +46,6 @@ jQuery(function($){
     if (orderDir){ data.order = orderDir; }
     const search = $root.find('.np-search').val();
     if (search){ data.s = search; }
-    const price = syncPriceUI($root);
-    if (price.min != null) data.min_price = price.min;
-    if (price.max != null) data.max_price = price.max;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
@@ -93,15 +60,11 @@ jQuery(function($){
     const params = new URLSearchParams();
     const defaultPer = getDefaultPerPage($root);
     const defaultPage = getDefaultPage($root);
-    const defaultMin = getDefaultMinPrice($root);
-    const defaultMax = getDefaultMaxPrice($root);
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
-      if (key === 'min_price' && defaultMin !== null && parseFloat(obj[key]) === defaultMin) return;
-      if (key === 'max_price' && defaultMax !== null && parseFloat(obj[key]) === defaultMax) return;
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -156,8 +119,6 @@ jQuery(function($){
     setCurrentPage($root, getCurrentPage($root));
 
     $root.on('change', '.np-orderby select', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); })
-         .on('change', '.np-price__slider input[type=range]', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
     $root.on('keyup', '.np-search', function(e){ if (e.keyCode === 13){ resetToFirstPage($root); load($root, 1, {scroll:true}); } });
     $root.on('click', '.js-np-page', function(e){
       e.preventDefault();
@@ -170,12 +131,6 @@ jQuery(function($){
     bindAllToggle($root);
 
     const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price');
-    const pmax = url.searchParams.get('max_price');
-    if (pmin != null){ $root.find('.np-range-min').val(pmin); }
-    if (pmax != null){ $root.find('.np-range-max').val(pmax); }
-    syncPriceUI($root);
-
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       if (!group) return;

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -4,6 +4,8 @@ jQuery(function($){
     'popularity':'DESC'
   };
   const SCROLL_OFFSET = 120;
+  const PRICE_COLOR = '#083640';
+  const priceFormatter = typeof Intl !== 'undefined' ? new Intl.NumberFormat('es-CL', {minimumFractionDigits:0, maximumFractionDigits:2}) : null;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
   function getDefaultPerPage($root){
@@ -54,6 +56,12 @@ jQuery(function($){
         data['cat_'+group] = vals.join(',');
       }
     });
+    const priceDefaults = getPriceDefaults($root);
+    const priceCurrent = getPriceSelection($root);
+    if (priceDefaults && priceCurrent){
+      if (priceCurrent.min > priceDefaults.min){ data.price_min = priceCurrent.min; }
+      if (priceCurrent.max < priceDefaults.max){ data.price_max = priceCurrent.max; }
+    }
     return data;
   }
   function toQuery($root, obj){
@@ -68,6 +76,102 @@ jQuery(function($){
       params.set(key, obj[key]);
     });
     return params.toString();
+  }
+  function getPriceContainer($root){
+    const enabled = String($root.data('priceEnabled')) === '1';
+    if (!enabled) return $();
+    return $root.find('.np-price-range');
+  }
+  function getPriceDefaults($root){
+    const enabled = String($root.data('priceEnabled')) === '1';
+    if (!enabled) return null;
+    const min = parseFloat($root.data('priceDefaultMin'));
+    const max = parseFloat($root.data('priceDefaultMax'));
+    const step = parseFloat($root.data('priceStep'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max) || min >= max){ return null; }
+    return {
+      min: min,
+      max: max,
+      step: isFiniteNumber(step) && step > 0 ? step : 1
+    };
+  }
+  function getPriceSelection($root){
+    const $range = getPriceContainer($root);
+    if (!$range.length) return null;
+    const min = parseFloat($range.data('currentMin'));
+    const max = parseFloat($range.data('currentMax'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)) return null;
+    return {
+      min: Math.round(min * 100) / 100,
+      max: Math.round(max * 100) / 100
+    };
+  }
+  function formatPriceValue(value){
+    const number = parseFloat(value);
+    if (!isFiniteNumber(number)) return '$0';
+    if (priceFormatter){ return '$'+priceFormatter.format(number); }
+    return '$'+number.toFixed(0);
+  }
+  function updatePriceSliderUI($root){
+    const $range = getPriceContainer($root);
+    if (!$range.length) return;
+    const defaults = getPriceDefaults($root);
+    const current = getPriceSelection($root);
+    if (!defaults || !current) return;
+    const $minLabel = $range.find('.js-np-price-min-label');
+    const $maxLabel = $range.find('.js-np-price-max-label');
+    if ($minLabel.length){ $minLabel.text(formatPriceValue(current.min)); }
+    if ($maxLabel.length){ $maxLabel.text(formatPriceValue(current.max)); }
+    const total = defaults.max - defaults.min;
+    if (total <= 0) return;
+    const minPercent = ((current.min - defaults.min) / total) * 100;
+    const maxPercent = ((current.max - defaults.min) / total) * 100;
+    const $progress = $range.find('.np-price-range__progress');
+    if ($progress.length){
+      const width = Math.max(0, Math.min(100, maxPercent) - Math.max(0, Math.min(100, minPercent)));
+      const start = Math.max(0, Math.min(100, minPercent));
+      $progress.css({left: start + '%', width: width + '%', background: PRICE_COLOR});
+    }
+  }
+  function bindPriceRange($root){
+    const $range = getPriceContainer($root);
+    if (!$range.length) return;
+    const defaults = getPriceDefaults($root);
+    if (!defaults) return;
+    const $minInput = $range.find('.js-np-price-min');
+    const $maxInput = $range.find('.js-np-price-max');
+    const step = defaults.step;
+    $minInput.attr({min: defaults.min, max: defaults.max, step: step});
+    $maxInput.attr({min: defaults.min, max: defaults.max, step: step});
+    function clampValues(source){
+      let minVal = parseFloat($minInput.val());
+      let maxVal = parseFloat($maxInput.val());
+      if (!isFiniteNumber(minVal)) minVal = defaults.min;
+      if (!isFiniteNumber(maxVal)) maxVal = defaults.max;
+      minVal = Math.min(Math.max(minVal, defaults.min), defaults.max);
+      maxVal = Math.min(Math.max(maxVal, defaults.min), defaults.max);
+      if (minVal > maxVal){
+        if (source === $minInput[0]){
+          maxVal = minVal;
+          $maxInput.val(maxVal);
+        } else {
+          minVal = maxVal;
+          $minInput.val(minVal);
+        }
+      }
+      minVal = Math.round(minVal * 100) / 100;
+      maxVal = Math.round(maxVal * 100) / 100;
+      $range.data('currentMin', minVal);
+      $range.data('currentMax', maxVal);
+    }
+    clampValues();
+    updatePriceSliderUI($root);
+    const onInput = function(){ clampValues(this); updatePriceSliderUI($root); };
+    const onChange = function(){ clampValues(this); updatePriceSliderUI($root); resetToFirstPage($root); load($root, 1, {scroll:true}); };
+    $minInput.on('input', onInput);
+    $maxInput.on('input', onInput);
+    $minInput.on('change', onChange);
+    $maxInput.on('change', onChange);
   }
   function scrollToStore($root){
     const $target = $root.find('.norpumps-grid');
@@ -129,6 +233,7 @@ jQuery(function($){
     });
 
     bindAllToggle($root);
+    bindPriceRange($root);
 
     const url = new URL(window.location.href);
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
@@ -155,6 +260,24 @@ jQuery(function($){
     if (isFiniteNumber(queryPer) && queryPer > 0){ setPerPage($root, queryPer); }
     const queryPage = parseInt(url.searchParams.get('page'), 10);
     if (isFiniteNumber(queryPage) && queryPage > 0){ setCurrentPage($root, queryPage); }
+
+    const priceDefaults = getPriceDefaults($root);
+    if (priceDefaults){
+      const priceCurrent = getPriceSelection($root);
+      const queryMin = parseFloat(url.searchParams.get('price_min'));
+      const queryMax = parseFloat(url.searchParams.get('price_max'));
+      const $range = getPriceContainer($root);
+      let minVal = priceCurrent ? priceCurrent.min : priceDefaults.min;
+      let maxVal = priceCurrent ? priceCurrent.max : priceDefaults.max;
+      if (isFiniteNumber(queryMin) && queryMin >= priceDefaults.min && queryMin <= priceDefaults.max){ minVal = queryMin; }
+      if (isFiniteNumber(queryMax) && queryMax >= priceDefaults.min && queryMax <= priceDefaults.max){ maxVal = queryMax; }
+      if (minVal > maxVal){ minVal = maxVal; }
+      $range.data('currentMin', Math.round(minVal * 100) / 100);
+      $range.data('currentMax', Math.round(maxVal * 100) / 100);
+      $range.find('.js-np-price-min').val(minVal);
+      $range.find('.js-np-price-max').val(maxVal);
+      updatePriceSliderUI($root);
+    }
 
     load($root, getCurrentPage($root), {scroll:false});
   });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,9 +1,5 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$default_min = isset($default_min_price) ? floatval($default_min_price) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
-$default_max = isset($default_max_price) ? floatval($default_max_price) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
-$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $default_min;
-$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $default_max;
 $current_per_page = isset($requested_per_page) ? intval($requested_per_page) : (isset($per_page) ? intval($per_page) : 12);
 $current_page = isset($requested_page) ? intval($requested_page) : 1;
 $default_page_attr = isset($default_page) ? intval($default_page) : 1;
@@ -12,14 +8,12 @@ $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($default_min); ?>" data-default-max-price="<?php echo esc_attr($default_max); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
       <select class="np-orderby">
         <option value="menu_order title" <?php selected($orderby_value, 'menu_order title'); ?>><?php esc_html_e('Predeterminado','norpumps'); ?></option>
-        <option value="price" <?php selected($orderby_value, 'price'); ?>><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
-        <option value="price-desc" <?php selected($orderby_value, 'price-desc'); ?>><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
         <option value="date" <?php selected($orderby_value, 'date'); ?>><?php esc_html_e('Novedades','norpumps'); ?></option>
         <option value="popularity" <?php selected($orderby_value, 'popularity'); ?>><?php esc_html_e('Popularidad','norpumps'); ?></option>
       </select>
@@ -31,25 +25,6 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
-      <?php if (in_array('price',$filters_arr)): ?>
-      <div class="np-filter">
-        <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
-        <div class="np-filter__body">
-          <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($default_min); ?>" data-max="<?php echo esc_attr($default_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_max); ?>">
-            </div>
-            <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($current_min); ?></span>
-              <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($current_max); ?></span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <?php endif; ?>
-
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,16 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_filter = isset($price_filter_data) ? $price_filter_data : ['enabled'=>false];
+if (!function_exists('np_format_price_label')){
+  function np_format_price_label($value){
+    $number = floatval($value);
+    $decimals = fmod($number, 1.0) === 0.0 ? 0 : 2;
+    return '$'.number_format($number, $decimals, ',', '.');
+  }
+}
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-enabled="<?php echo !empty($price_filter['enabled']) ? '1' : '0'; ?>" data-price-default-min="<?php echo esc_attr(number_format(floatval($price_filter['default_min'] ?? 0), 2, '.', '')); ?>" data-price-default-max="<?php echo esc_attr(number_format(floatval($price_filter['default_max'] ?? 0), 2, '.', '')); ?>" data-price-current-min="<?php echo esc_attr(number_format(floatval($price_filter['current_min'] ?? 0), 2, '.', '')); ?>" data-price-current-max="<?php echo esc_attr(number_format(floatval($price_filter['current_max'] ?? 0), 2, '.', '')); ?>" data-price-step="<?php echo esc_attr(number_format(floatval($price_filter['step'] ?? 1), 2, '.', '')); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -25,6 +33,38 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (!empty($price_filter['enabled'])): ?>
+        <?php
+          $default_min = floatval($price_filter['default_min']);
+          $default_max = floatval($price_filter['default_max']);
+          $current_min = floatval($price_filter['current_min']);
+          $current_max = floatval($price_filter['current_max']);
+          $step = floatval($price_filter['step']);
+          if ($step <= 0){ $step = 1; }
+        ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-min="<?php echo esc_attr(number_format($default_min, 2, '.', '')); ?>" data-max="<?php echo esc_attr(number_format($default_max, 2, '.', '')); ?>" data-step="<?php echo esc_attr(number_format($step, 2, '.', '')); ?>" data-current-min="<?php echo esc_attr(number_format($current_min, 2, '.', '')); ?>" data-current-max="<?php echo esc_attr(number_format($current_max, 2, '.', '')); ?>">
+              <div class="np-price-range__values">
+                <span class="np-price-range__pill">
+                  <span class="np-price-range__label"><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                  <span class="np-price-range__value js-np-price-min-label"><?php echo esc_html(np_format_price_label($current_min)); ?></span>
+                </span>
+                <span class="np-price-range__pill">
+                  <span class="np-price-range__label"><?php esc_html_e('Máximo','norpumps'); ?></span>
+                  <span class="np-price-range__value js-np-price-max-label"><?php echo esc_html(np_format_price_label($current_max)); ?></span>
+                </span>
+              </div>
+              <div class="np-price-range__inputs">
+                <div class="np-price-range__progress"></div>
+                <input type="range" class="np-price-range__input js-np-price-min" min="<?php echo esc_attr(number_format($default_min, 2, '.', '')); ?>" max="<?php echo esc_attr(number_format($default_max, 2, '.', '')); ?>" step="<?php echo esc_attr(number_format($step, 2, '.', '')); ?>" value="<?php echo esc_attr(number_format($current_min, 2, '.', '')); ?>">
+                <input type="range" class="np-price-range__input js-np-price-max" min="<?php echo esc_attr(number_format($default_min, 2, '.', '')); ?>" max="<?php echo esc_attr(number_format($default_max, 2, '.', '')); ?>" step="<?php echo esc_attr(number_format($step, 2, '.', '')); ?>" value="<?php echo esc_attr(number_format($current_max, 2, '.', '')); ?>">
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/norpumps.php
+++ b/norpumps.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: NorPumps Suite
- * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
+ * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
  * Version: 1.2.2
  * Author: Alfonso (fiverr)
  * Requires at least: 6.0


### PR DESCRIPTION
## Summary
- add a configurable price range filter to the store frontend and combine it with existing AJAX filters
- expose price range attributes in the shortcode and wire them into product queries
- extend the admin generator UI with options for enabling the price filter and defining its range

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f03123e0608330ab509621a9cfda4e