### PR TITLE
Add combined price range filtering support

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,6 +9,7 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.np-filter--price .np-filter__body{ padding-top:18px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
@@ -37,6 +38,23 @@
 .np-pagination__ellipsis{ padding:6px 8px; color:#6a7a83; }
 .np-pagination__link{ display:inline-flex; align-items:center; justify-content:center; min-width:36px; min-height:36px; padding:0 10px; border-radius:999px; color:var(--np-text); border:1px solid transparent; font-weight:600; transition:all .2s ease; }
 .np-pagination__link:hover{ border-color:var(--np-accent); color:var(--np-accent); }
+.np-price-range{ display:flex; flex-direction:column; gap:16px; }
+.np-price-range__values{ display:flex; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+.np-price-range__pill{ flex:1 1 120px; background:#f3f7f8; border-radius:999px; padding:10px 14px; display:flex; flex-direction:column; gap:2px; color:#083640; font-weight:600; box-shadow:inset 0 0 0 1px rgba(8,54,64,0.08); }
+.np-price-range__label{ font-size:12px; text-transform:uppercase; letter-spacing:.04em; opacity:.75; }
+.np-price-range__value{ font-size:18px; letter-spacing:.01em; }
+.np-price-range__track{ position:relative; height:16px; background:rgba(8,54,64,0.12); border-radius:999px; }
+.np-price-range__progress{ position:absolute; inset:0; background:#083640; border-radius:999px; opacity:.65; }
+.np-price-range__track, .np-price-range__thumb{ touch-action:none; }
+.np-price-range__thumb{ position:absolute; top:50%; width:24px; height:24px; background:#083640; border-radius:50%; border:none; transform:translate(-50%, -50%); box-shadow:0 6px 16px rgba(8,54,64,0.35); cursor:grab; transition:transform .15s ease, box-shadow .15s ease; }
+.np-price-range__thumb:focus{ outline:none; box-shadow:0 0 0 4px rgba(8,54,64,0.2); }
+.np-price-range__thumb:active{ cursor:grabbing; transform:translate(-50%, -50%) scale(1.05); }
+.np-price-range__thumb::after{ content:''; position:absolute; inset:6px; background:#fff; border-radius:50%; }
+.np-price-range__track::before, .np-price-range__track::after{ content:''; position:absolute; top:50%; width:12px; height:12px; border-radius:50%; background:#083640; transform:translate(-50%, -50%); opacity:.3; }
+.np-price-range__track::before{ left:0; }
+.np-price-range__track::after{ right:0; }
+.np-price-range.is-disabled .np-price-range__thumb{ opacity:.4; pointer-events:none; }
+.np-price-range.is-dragging .np-price-range__thumb{ transition:none; }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,6 +7,18 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_defaults = isset($filters_price_defaults) ? $filters_price_defaults : ['min'=>0,'max'=>100,'step'=>1];
+$price_current_min = isset($price_request_min) ? $price_request_min : $price_defaults['min'];
+$price_current_max = isset($price_request_max) ? $price_request_max : $price_defaults['max'];
+$price_decimals = function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : absint(get_option('woocommerce_price_num_decimals', 0));
+$price_symbol = function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$';
+$price_locale = function_exists('get_locale') ? get_locale() : 'es-CL';
+$price_locale_attr = str_replace('_','-', $price_locale);
+$price_min_attr = number_format((float)$price_defaults['min'], $price_decimals, '.', '');
+$price_max_attr = number_format((float)$price_defaults['max'], $price_decimals, '.', '');
+$price_step_attr = number_format((float)$price_defaults['step'], $price_decimals, '.', '');
+$price_current_min_attr = number_format((float)$price_current_min, $price_decimals, '.', '');
+$price_current_max_attr = number_format((float)$price_current_max, $price_decimals, '.', '');
 ?>
 <div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
   <div class="norpumps-store__header">
@@ -27,6 +39,30 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (in_array('price',$filters_arr, true)): ?>
+        <div class="np-filter np-filter--price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-min="<?php echo esc_attr($price_min_attr); ?>" data-max="<?php echo esc_attr($price_max_attr); ?>" data-step="<?php echo esc_attr($price_step_attr); ?>" data-current-min="<?php echo esc_attr($price_current_min_attr); ?>" data-current-max="<?php echo esc_attr($price_current_max_attr); ?>" data-symbol="<?php echo esc_attr($price_symbol); ?>" data-locale="<?php echo esc_attr($price_locale_attr); ?>" data-decimals="<?php echo esc_attr($price_decimals); ?>">
+              <div class="np-price-range__values">
+                <span class="np-price-range__pill">
+                  <span class="np-price-range__label"><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                  <span class="np-price-range__value js-np-price-min-label"></span>
+                </span>
+                <span class="np-price-range__pill">
+                  <span class="np-price-range__label"><?php esc_html_e('Máximo','norpumps'); ?></span>
+                  <span class="np-price-range__value js-np-price-max-label"></span>
+                </span>
+              </div>
+              <div class="np-price-range__track">
+                <div class="np-price-range__progress"></div>
+                <button type="button" class="np-price-range__thumb is-min" data-handle="min" role="slider" aria-valuemin="<?php echo esc_attr($price_min_attr); ?>" aria-valuemax="<?php echo esc_attr($price_max_attr); ?>" aria-label="<?php esc_attr_e('Precio mínimo','norpumps'); ?>"></button>
+                <button type="button" class="np-price-range__thumb is-max" data-handle="max" role="slider" aria-valuemin="<?php echo esc_attr($price_min_attr); ?>" aria-valuemax="<?php echo esc_attr($price_max_attr); ?>" aria-label="<?php esc_attr_e('Precio máximo','norpumps'); ?>"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add an optional price range filter section with a dual-handle slider that works alongside category filters and pagination
- expose shortcode options and admin generator controls for setting minimum, maximum, and step defaults while keeping the UI styled to match the store
- send min/max price constraints through AJAX and WooCommerce queries so URLs, pagination, and other filters stay in sync

## Testing
- `php -l modules/store/module.php`


------
https://chatgpt.com/codex/tasks/task_e_68f0369253748330ab062fa22e3aaf1b