### PR TITLE
Add price range filter with slider UI

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -9,6 +9,34 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.norpumps-filters .np-filter--price .np-filter__body{ background:linear-gradient(180deg,#f7fbfc 0%,#eef5f6 100%); border:1px solid rgba(8,54,64,0.1); }
+.np-price-range{ display:flex; flex-direction:column; gap:16px; padding:16px; background:#fff; border-radius:14px; border:1px solid rgba(8,54,64,0.12); box-shadow:0 8px 24px rgba(8,54,64,0.08); }
+.np-price-range__summary{ display:flex; justify-content:space-between; align-items:center; font-weight:600; color:#083640; text-transform:uppercase; letter-spacing:.04em; font-size:12px; }
+.np-price-range__values{ display:flex; align-items:center; gap:8px; font-size:15px; letter-spacing:normal; text-transform:none; }
+.np-price-range__value{ font-weight:700; color:#083640; }
+.np-price-range__fields{ display:flex; gap:12px; }
+.np-price-field{ flex:1; display:flex; flex-direction:column; gap:6px; font-size:12px; color:#0f2a33; text-transform:uppercase; letter-spacing:.04em; }
+.np-price-input{ padding:10px 12px; border:1px solid rgba(8,54,64,0.25); border-radius:10px; font-size:14px; font-weight:600; color:#083640; background:#f9fdfd; transition:border-color .2s ease, box-shadow .2s ease; }
+.np-price-input:focus{ border-color:#083640; box-shadow:0 0 0 3px rgba(8,54,64,0.12); outline:none; background:#fff; }
+.np-price-range__slider{ position:relative; height:42px; display:flex; align-items:center; }
+.np-price-range__track{ position:absolute; inset:0 12px; height:8px; background:rgba(8,54,64,0.15); border-radius:999px; overflow:hidden; }
+.np-price-range__progress{ position:absolute; top:0; bottom:0; left:0; right:0; background:#083640; border-radius:999px; }
+.np-price-range__input{ position:absolute; left:0; right:0; width:100%; height:100%; background:transparent; pointer-events:none; -webkit-appearance:none; appearance:none; }
+.np-price-range__input.js-np-price-min{ z-index:2; }
+.np-price-range__input.js-np-price-max{ z-index:3; }
+.np-price-range__input::-webkit-slider-thumb{ pointer-events:auto; -webkit-appearance:none; appearance:none; width:18px; height:18px; border-radius:50%; background:#fff; border:3px solid #083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); transition:transform .15s ease; }
+.np-price-range__input::-webkit-slider-thumb:active{ transform:scale(1.1); }
+.np-price-range__input::-moz-range-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:#fff; border:3px solid #083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); transition:transform .15s ease; }
+.np-price-range__input::-moz-range-thumb:active{ transform:scale(1.1); }
+.np-price-range__input::-ms-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:#fff; border:3px solid #083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); }
+.np-price-range__input::-webkit-slider-runnable-track{ height:8px; background:transparent; }
+.np-price-range__input::-moz-range-track{ height:8px; background:transparent; }
+.np-price-range__input::-ms-track{ height:8px; background:transparent; border-color:transparent; color:transparent; }
+.np-price-range__sep{ color:#4a6970; font-weight:400; }
+@media(max-width: 600px){
+  .np-price-range__fields{ flex-direction:column; }
+  .np-price-range__summary{ flex-direction:column; gap:6px; align-items:flex-start; }
+}
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,6 +9,34 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.norpumps-filters .np-filter--price .np-filter__body{ background:linear-gradient(180deg,#f7fbfc 0%,#eef5f6 100%); border:1px solid rgba(8,54,64,0.1); }
+.np-price-range{ display:flex; flex-direction:column; gap:16px; padding:16px; background:#fff; border-radius:14px; border:1px solid rgba(8,54,64,0.12); box-shadow:0 8px 24px rgba(8,54,64,0.08); }
+.np-price-range__summary{ display:flex; justify-content:space-between; align-items:center; font-weight:600; color:#083640; text-transform:uppercase; letter-spacing:.04em; font-size:12px; }
+.np-price-range__values{ display:flex; align-items:center; gap:8px; font-size:15px; letter-spacing:normal; text-transform:none; }
+.np-price-range__value{ font-weight:700; color:#083640; }
+.np-price-range__fields{ display:flex; gap:12px; }
+.np-price-field{ flex:1; display:flex; flex-direction:column; gap:6px; font-size:12px; color:#0f2a33; text-transform:uppercase; letter-spacing:.04em; }
+.np-price-input{ padding:10px 12px; border:1px solid rgba(8,54,64,0.25); border-radius:10px; font-size:14px; font-weight:600; color:#083640; background:#f9fdfd; transition:border-color .2s ease, box-shadow .2s ease; }
+.np-price-input:focus{ border-color:#083640; box-shadow:0 0 0 3px rgba(8,54,64,0.12); outline:none; background:#fff; }
+.np-price-range__slider{ position:relative; height:42px; display:flex; align-items:center; }
+.np-price-range__track{ position:absolute; inset:0 12px; height:8px; background:rgba(8,54,64,0.15); border-radius:999px; overflow:hidden; }
+.np-price-range__progress{ position:absolute; top:0; bottom:0; left:0; right:0; background:#083640; border-radius:999px; }
+.np-price-range__input{ position:absolute; left:0; right:0; width:100%; height:100%; background:transparent; pointer-events:none; -webkit-appearance:none; appearance:none; }
+.np-price-range__input.js-np-price-min{ z-index:2; }
+.np-price-range__input.js-np-price-max{ z-index:3; }
+.np-price-range__input::-webkit-slider-thumb{ pointer-events:auto; -webkit-appearance:none; appearance:none; width:18px; height:18px; border-radius:50%; background:#fff; border:3px solid #083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); transition:transform .15s ease; }
+.np-price-range__input::-webkit-slider-thumb:active{ transform:scale(1.1); }
+.np-price-range__input::-moz-range-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:#fff; border:3px solid #083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); transition:transform .15s ease; }
+.np-price-range__input::-moz-range-thumb:active{ transform:scale(1.1); }
+.np-price-range__input::-ms-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:#fff; border:3px solid #083640; box-shadow:0 4px 10px rgba(8,54,64,0.25); }
+.np-price-range__input::-webkit-slider-runnable-track{ height:8px; background:transparent; }
+.np-price-range__input::-moz-range-track{ height:8px; background:transparent; }
+.np-price-range__input::-ms-track{ height:8px; background:transparent; border-color:transparent; color:transparent; }
+.np-price-range__sep{ color:#4a6970; font-weight:400; }
+@media(max-width: 600px){
+  .np-price-range__fields{ flex-direction:column; }
+  .np-price-range__summary{ flex-direction:column; gap:6px; align-items:flex-start; }
+}
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,29 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_attrs = '';
+$price_decimals = (isset($price_step) && floor($price_step) != $price_step) ? 2 : 0;
+if (in_array('price', $filters_arr, true)){
+  $currency_symbol = '$';
+  if (function_exists('get_woocommerce_currency_symbol')){
+    $currency_symbol = html_entity_decode(get_woocommerce_currency_symbol(), ENT_QUOTES, get_bloginfo('charset'));
+  }
+  $price_attrs = sprintf(
+    ' data-price-min="%1$s" data-price-max="%2$s" data-price-step="%3$s" data-price-currency="%4$s" data-price-current-min="%5$s" data-price-current-max="%6$s" data-price-decimals="%7$s"',
+    esc_attr($price_min_default),
+    esc_attr($price_max_default),
+    esc_attr($price_step),
+    esc_attr($currency_symbol),
+    esc_attr($requested_price_min),
+    esc_attr($requested_price_max),
+    esc_attr($price_decimals)
+  );
+  $np_format_price = function($value) use ($currency_symbol, $price_decimals) {
+    return $currency_symbol . number_format_i18n($value, $price_decimals);
+  };
+}
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>"<?php echo $price_attrs; ?>>
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +48,40 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (in_array('price',$filters_arr, true)): ?>
+        <div class="np-filter np-filter--price" data-group="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-min="<?php echo esc_attr($price_min_default); ?>" data-max="<?php echo esc_attr($price_max_default); ?>" data-step="<?php echo esc_attr($price_step); ?>" data-current-min="<?php echo esc_attr($requested_price_min); ?>" data-current-max="<?php echo esc_attr($requested_price_max); ?>" data-currency="<?php echo esc_attr($currency_symbol ?? ''); ?>" data-decimals="<?php echo esc_attr($price_decimals); ?>">
+              <div class="np-price-range__summary">
+                <span class="np-price-range__label"><?php esc_html_e('Rango seleccionado','norpumps'); ?></span>
+                <span class="np-price-range__values">
+                  <span class="np-price-range__value js-np-price-min-label"><?php echo esc_html($np_format_price($requested_price_min)); ?></span>
+                  <span class="np-price-range__sep">—</span>
+                  <span class="np-price-range__value js-np-price-max-label"><?php echo esc_html($np_format_price($requested_price_max)); ?></span>
+                </span>
+              </div>
+              <div class="np-price-range__fields">
+                <label class="np-price-field">
+                  <span><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                  <input type="number" class="np-price-input js-np-price-min-input" inputmode="decimal" min="<?php echo esc_attr($price_min_default); ?>" max="<?php echo esc_attr($price_max_default); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($requested_price_min); ?>">
+                </label>
+                <label class="np-price-field">
+                  <span><?php esc_html_e('Máximo','norpumps'); ?></span>
+                  <input type="number" class="np-price-input js-np-price-max-input" inputmode="decimal" min="<?php echo esc_attr($price_min_default); ?>" max="<?php echo esc_attr($price_max_default); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($requested_price_max); ?>">
+                </label>
+              </div>
+              <div class="np-price-range__slider">
+                <div class="np-price-range__track">
+                  <div class="np-price-range__progress"></div>
+                </div>
+                <input type="range" class="np-price-range__input js-np-price-min" min="<?php echo esc_attr($price_min_default); ?>" max="<?php echo esc_attr($price_max_default); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($requested_price_min); ?>">
+                <input type="range" class="np-price-range__input js-np-price-max" min="<?php echo esc_attr($price_min_default); ?>" max="<?php echo esc_attr($price_max_default); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($requested_price_max); ?>">
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add price filter controls to the store generator, shortcode defaults, and WooCommerce query handling
- implement a responsive price range slider that syncs with AJAX filtering and query parameters
- style the new price filter for both frontend and admin experiences

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f03bce9ac48330a369d225ce16aaf6