### PR TITLE
Add price range slider filter to store module

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,6 +13,22 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
+.np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:14px; }
+.np-price-range{ display:flex; flex-direction:column; gap:16px; }
+.np-price-range__fields{ display:flex; gap:14px; justify-content:space-between; }
+.np-price-range__fields label{ flex:1; display:flex; flex-direction:column; gap:6px; font-weight:600; color:#083640; font-size:14px; text-transform:uppercase; letter-spacing:.04em; }
+.np-price-range__fields input{ width:100%; border:1px solid var(--np-border); border-radius:10px; padding:10px 12px; font-size:15px; font-weight:600; color:#083640; background:#f4f8f9; transition:border-color .2s ease, box-shadow .2s ease; }
+.np-price-range__fields input:focus{ outline:none; border-color:#083640; box-shadow:0 0 0 3px rgba(8,54,64,.1); }
+.np-price-range__slider{ position:relative; height:10px; background:#dfe8ea; border-radius:999px; overflow:hidden; }
+.np-price-range__track{ position:absolute; inset:0; background:#083640; border-radius:inherit; box-shadow:0 6px 18px rgba(8,54,64,.25); }
+.np-price-range__ranges{ position:relative; height:0; }
+.np-price-range__range{ position:absolute; width:100%; height:12px; top:-22px; left:0; pointer-events:none; background:none; -webkit-appearance:none; appearance:none; }
+.np-price-range__range::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:22px; height:22px; border-radius:50%; background:#fff; border:3px solid #083640; pointer-events:auto; box-shadow:0 4px 12px rgba(8,54,64,.25); cursor:pointer; transition:transform .2s ease, box-shadow .2s ease; }
+.np-price-range__range::-moz-range-thumb{ width:22px; height:22px; border-radius:50%; background:#fff; border:3px solid #083640; pointer-events:auto; box-shadow:0 4px 12px rgba(8,54,64,.25); cursor:pointer; transition:transform .2s ease, box-shadow .2s ease; }
+.np-price-range__range::-webkit-slider-thumb:hover, .np-price-range__range::-moz-range-thumb:hover{ transform:scale(1.05); box-shadow:0 6px 16px rgba(8,54,64,.35); }
+.np-price-range__range::-webkit-slider-runnable-track{ background:transparent; }
+.np-price-range__range::-moz-range-track{ background:transparent; }
+.np-price-range__legend{ display:flex; justify-content:space-between; font-weight:600; color:#083640; font-size:13px; text-transform:uppercase; letter-spacing:.04em; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -7,6 +7,87 @@ jQuery(function($){
   };
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
+  function parseNumber(value, fallback){
+    const num = parseFloat(value);
+    return isFiniteNumber(num) ? num : fallback;
+  }
+  function getPriceRangeElement($root){
+    const $range = $root.find('.np-price-range');
+    return $range.length ? $range : null;
+  }
+  function getPriceBoundsFromRange($range){
+    if (!$range) return null;
+    const min = parseNumber($range.data('min'), null);
+    const max = parseNumber($range.data('max'), null);
+    const step = parseNumber($range.data('step'), 1) || 1;
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)) return null;
+    if (max < min){ return {min:max, max:min, step:step}; }
+    return {min:min, max:max, step:step};
+  }
+  function getPriceValuesFromRange($range){
+    if (!$range) return null;
+    const min = parseNumber($range.data('valueMin'), null);
+    const max = parseNumber($range.data('valueMax'), null);
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)) return null;
+    return {min:min, max:max};
+  }
+  function normalizePriceValues(bounds, minValue, maxValue, prefer){
+    const min = Math.max(bounds.min, Math.min(minValue, bounds.max));
+    const max = Math.max(bounds.min, Math.min(maxValue, bounds.max));
+    if (bounds.max === bounds.min){
+      return {min:bounds.min, max:bounds.max};
+    }
+    if (prefer === 'min' && min > max){
+      return {min:min, max:min};
+    }
+    if (prefer === 'max' && max < min){
+      return {min:max, max:max};
+    }
+    if (min > max){
+      const mid = Math.max(min, max);
+      return {min:mid, max:mid};
+    }
+    return {min:min, max:max};
+  }
+  function updatePriceValues($range, minValue, maxValue, options){
+    if (!$range) return;
+    const bounds = getPriceBoundsFromRange($range);
+    if (!bounds) return;
+    const opts = $.extend({updateInputs:true, updateRanges:true}, options);
+    const values = normalizePriceValues(bounds, minValue, maxValue, null);
+    $range.data('valueMin', values.min).attr('data-value-min', values.min);
+    $range.data('valueMax', values.max).attr('data-value-max', values.max);
+    if (opts.updateInputs){
+      $range.find('.np-price-range__input--min').val(values.min);
+      $range.find('.np-price-range__input--max').val(values.max);
+    }
+    if (opts.updateRanges){
+      $range.find('.np-price-range__range--min').val(values.min);
+      $range.find('.np-price-range__range--max').val(values.max);
+    }
+    updatePriceTrack($range, bounds, values);
+  }
+  function updatePriceTrack($range, bounds, values){
+    if (!$range) return;
+    const realBounds = bounds || getPriceBoundsFromRange($range);
+    const realValues = values || getPriceValuesFromRange($range);
+    const $track = $range.find('.np-price-range__track');
+    if (!$track.length || !realBounds || !realValues){ return; }
+    const span = Math.max(realBounds.max - realBounds.min, 1);
+    const left = ((realValues.min - realBounds.min) / span) * 100;
+    const right = ((realValues.max - realBounds.min) / span) * 100;
+    const safeLeft = Math.min(Math.max(left, 0), 100);
+    const safeRight = Math.min(Math.max(right, 0), 100);
+    $track.css({ left: safeLeft + '%', right: (100 - safeRight) + '%' });
+  }
+  function getPriceState($root){
+    const $range = getPriceRangeElement($root);
+    if (!$range) return null;
+    const bounds = getPriceBoundsFromRange($range);
+    if (!bounds) return null;
+    const values = getPriceValuesFromRange($range) || {min:bounds.min, max:bounds.max};
+    return {min:values.min, max:values.max, bounds:bounds, $range:$range};
+  }
 
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
@@ -56,6 +137,13 @@ jQuery(function($){
         data['cat_'+group] = vals.join(',');
       }
     });
+    const priceState = getPriceState($root);
+    if (priceState && priceState.bounds){
+      if (priceState.min > priceState.bounds.min || priceState.max < priceState.bounds.max){
+        data.price_min = priceState.min;
+        data.price_max = priceState.max;
+      }
+    }
     return data;
   }
   function toQuery($root, obj){
@@ -69,6 +157,16 @@ jQuery(function($){
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
       params.set(key, obj[key]);
     });
+    const priceState = getPriceState($root);
+    if (priceState && priceState.bounds){
+      if (priceState.min > priceState.bounds.min || priceState.max < priceState.bounds.max){
+        params.set('price_min', priceState.min);
+        params.set('price_max', priceState.max);
+      } else {
+        params.delete('price_min');
+        params.delete('price_max');
+      }
+    }
     return params.toString();
   }
   function scrollToStore($root){
@@ -114,6 +212,50 @@ jQuery(function($){
       load($root, 1, {scroll:true});
     });
   }
+  function bindPriceRange($root){
+    const $range = getPriceRangeElement($root);
+    if (!$range) return;
+    const bounds = getPriceBoundsFromRange($range);
+    if (!bounds) return;
+    const initialValues = getPriceValuesFromRange($range) || {min:bounds.min, max:bounds.max};
+    updatePriceValues($range, initialValues.min, initialValues.max);
+
+    function handleRangeInput(prefer){
+      const minVal = parseNumber($range.find('.np-price-range__range--min').val(), bounds.min);
+      const maxVal = parseNumber($range.find('.np-price-range__range--max').val(), bounds.max);
+      const normalized = normalizePriceValues(bounds, minVal, maxVal, prefer);
+      updatePriceValues($range, normalized.min, normalized.max);
+      return normalized;
+    }
+    function handleNumberInput(prefer){
+      const minVal = parseNumber($range.find('.np-price-range__input--min').val(), bounds.min);
+      const maxVal = parseNumber($range.find('.np-price-range__input--max').val(), bounds.max);
+      const normalized = normalizePriceValues(bounds, minVal, maxVal, prefer);
+      updatePriceValues($range, normalized.min, normalized.max);
+      return normalized;
+    }
+
+    $range.on('input', '.np-price-range__range', function(){
+      const prefer = $(this).hasClass('np-price-range__range--min') ? 'min' : 'max';
+      handleRangeInput(prefer);
+    });
+    $range.on('change', '.np-price-range__range', function(){
+      const prefer = $(this).hasClass('np-price-range__range--min') ? 'min' : 'max';
+      handleRangeInput(prefer);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+    $range.on('input', '.np-price-range__input', function(){
+      const prefer = $(this).hasClass('np-price-range__input--min') ? 'min' : 'max';
+      handleNumberInput(prefer);
+    });
+    $range.on('change', '.np-price-range__input', function(){
+      const prefer = $(this).hasClass('np-price-range__input--min') ? 'min' : 'max';
+      handleNumberInput(prefer);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+  }
 
   $('.norpumps-store').each(function(){
     const $root = $(this);
@@ -131,6 +273,7 @@ jQuery(function($){
     });
 
     bindAllToggle($root);
+    bindPriceRange($root);
 
     const url = new URL(window.location.href);
 

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -27,6 +27,50 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (in_array('price',$filters_arr, true)): ?>
+        <?php
+          $price_bounds_min = isset($price_min_bound) ? floatval($price_min_bound) : 0;
+          $price_bounds_max = isset($price_max_bound) ? floatval($price_max_bound) : $price_bounds_min;
+          $price_current_min = isset($requested_price_min) ? floatval($requested_price_min) : $price_bounds_min;
+          $price_current_max = isset($requested_price_max) ? floatval($requested_price_max) : $price_bounds_max;
+          if ($price_current_min < $price_bounds_min) { $price_current_min = $price_bounds_min; }
+          if ($price_current_max > $price_bounds_max) { $price_current_max = $price_bounds_max; }
+          if ($price_current_min > $price_current_max) { $price_current_min = $price_bounds_min; $price_current_max = $price_bounds_max; }
+          $price_step_value = isset($price_step) ? floatval($price_step) : 1;
+        ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-min="<?php echo esc_attr($price_bounds_min); ?>" data-max="<?php echo esc_attr($price_bounds_max); ?>" data-step="<?php echo esc_attr($price_step_value); ?>" data-value-min="<?php echo esc_attr($price_current_min); ?>" data-value-max="<?php echo esc_attr($price_current_max); ?>">
+              <div class="np-price-range__fields">
+                <label>
+                  <span><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                  <input type="number" class="np-price-range__input np-price-range__input--min" value="<?php echo esc_attr($price_current_min); ?>" min="<?php echo esc_attr($price_bounds_min); ?>" max="<?php echo esc_attr($price_bounds_max); ?>" step="<?php echo esc_attr($price_step_value); ?>">
+                </label>
+                <label>
+                  <span><?php esc_html_e('Máximo','norpumps'); ?></span>
+                  <input type="number" class="np-price-range__input np-price-range__input--max" value="<?php echo esc_attr($price_current_max); ?>" min="<?php echo esc_attr($price_bounds_min); ?>" max="<?php echo esc_attr($price_bounds_max); ?>" step="<?php echo esc_attr($price_step_value); ?>">
+                </label>
+              </div>
+              <div class="np-price-range__slider">
+                <div class="np-price-range__track"></div>
+              </div>
+              <div class="np-price-range__ranges">
+                <input type="range" class="np-price-range__range np-price-range__range--min" min="<?php echo esc_attr($price_bounds_min); ?>" max="<?php echo esc_attr($price_bounds_max); ?>" step="<?php echo esc_attr($price_step_value); ?>" value="<?php echo esc_attr($price_current_min); ?>">
+                <input type="range" class="np-price-range__range np-price-range__range--max" min="<?php echo esc_attr($price_bounds_min); ?>" max="<?php echo esc_attr($price_bounds_max); ?>" step="<?php echo esc_attr($price_step_value); ?>" value="<?php echo esc_attr($price_current_max); ?>">
+              </div>
+              <div class="np-price-range__legend">
+                <?php
+                  $legend_min = function_exists('wc_price') ? wc_price($price_bounds_min) : number_format_i18n($price_bounds_min);
+                  $legend_max = function_exists('wc_price') ? wc_price($price_bounds_max) : number_format_i18n($price_bounds_max);
+                ?>
+                <span><?php echo wp_kses_post($legend_min); ?></span>
+                <span><?php echo wp_kses_post($legend_max); ?></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add a price range slider filter that works with the existing AJAX store listing
- extend the store shortcode and admin generator to configure price bounds and persist selections in the URL
- refresh store assets with slider styling and JavaScript to keep filters, pagination, and search in sync

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f040caf87483309a76f418c106a472