### PR TITLE
Remove price filter functionality from store module

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -13,11 +13,6 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,11 +13,6 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
-.np-price__slider{ position:relative; height:30px; }
-.np-price__slider input[type=range]{ position:absolute; left:0; right:0; width:100%; pointer-events:none; -webkit-appearance:none; background:transparent; height:30px; }
-.np-price__slider input::-webkit-slider-thumb{ -webkit-appearance:none; pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; box-shadow:0 0 0 2px #0f5b62; }
-.np-price__slider input::-moz-range-thumb{ pointer-events:auto; width:16px; height:16px; border-radius:50%; background:#0f5b62; border:2px solid #fff; }
-.np-price__labels{ display:flex; justify-content:space-between; font-size:12px; color:#333; margin-top:8px; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -31,7 +31,17 @@
 .np-card__price{ font-weight:700; margin-bottom:8px; }
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
 .np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
-.np-pagination{ margin:20px 0; text-align:center; }
+.norpumps-store.is-loading .np-grid{ position:relative; opacity:.5; }
+.norpumps-store.is-loading .np-grid::after{ content:'Cargando…'; position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:14px; color:#0f5b62; background:rgba(255,255,255,0.65); border-radius:12px; }
+.np-pagination{ margin:24px 0 0; text-align:center; }
+.np-pagination__nav{ display:inline-block; background:#fff; border:1px solid var(--np-border); border-radius:999px; padding:6px 10px; box-shadow:0 6px 16px rgba(15,91,98,0.08); }
+.np-pagination__list{ list-style:none; display:flex; align-items:center; gap:4px; margin:0; padding:0; }
+.np-pagination__item{ }
+.np-pagination__item.is-active .np-pagination__link{ background:var(--np-accent); color:#fff; box-shadow:0 4px 10px rgba(15,91,98,0.25); }
+.np-pagination__item.is-disabled .np-pagination__link{ opacity:.35; pointer-events:none; }
+.np-pagination__ellipsis{ padding:6px 8px; color:#6a7a83; }
+.np-pagination__link{ display:inline-flex; align-items:center; justify-content:center; min-width:36px; min-height:36px; padding:0 10px; border-radius:999px; color:var(--np-text); border:1px solid transparent; font-weight:600; transition:all .2s ease; }
+.np-pagination__link:hover{ border-color:var(--np-accent); color:var(--np-accent); }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -8,11 +8,6 @@ jQuery(function($){
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
-  function clamp(value, min, max){
-    value = parseFloat(value || 0);
-    if (!isFiniteNumber(value)) value = min;
-    return Math.min(Math.max(value, min), max);
-  }
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
     return isFiniteNumber(val) && val > 0 ? val : 12;
@@ -43,29 +38,6 @@ jQuery(function($){
     setCurrentPage($root, fallback);
     return fallback;
   }
-  function getDefaultMinPrice($root){
-    const val = parseFloat($root.data('defaultMinPrice'));
-    return isFiniteNumber(val) ? val : null;
-  }
-  function getDefaultMaxPrice($root){
-    const val = parseFloat($root.data('defaultMaxPrice'));
-    return isFiniteNumber(val) ? val : null;
-  }
-  function syncPriceUI($root){
-    const $wrap = $root.find('.np-price__slider');
-    if (!$wrap.length) return {};
-    const sliderMin = parseFloat($wrap.data('min'));
-    const sliderMax = parseFloat($wrap.data('max'));
-    const $min = $wrap.find('.np-range-min');
-    const $max = $wrap.find('.np-range-max');
-    let vmin = clamp($min.val(), sliderMin, sliderMax);
-    let vmax = clamp($max.val(), sliderMin, sliderMax);
-    if (vmin > vmax){ const tmp = vmin; vmin = vmax; vmax = tmp; }
-    $min.val(vmin); $max.val(vmax);
-    $root.find('.np-price-min').text(vmin);
-    $root.find('.np-price-max').text(vmax);
-    return {min:vmin, max:vmax};
-  }
   function buildQuery($root){
     const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
     data.per_page = getPerPage($root);
@@ -76,9 +48,6 @@ jQuery(function($){
     if (orderDir){ data.order = orderDir; }
     const search = $root.find('.np-search').val();
     if (search){ data.s = search; }
-    const price = syncPriceUI($root);
-    if (price.min != null) data.min_price = price.min;
-    if (price.max != null) data.max_price = price.max;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
@@ -93,15 +62,11 @@ jQuery(function($){
     const params = new URLSearchParams();
     const defaultPer = getDefaultPerPage($root);
     const defaultPage = getDefaultPage($root);
-    const defaultMin = getDefaultMinPrice($root);
-    const defaultMax = getDefaultMaxPrice($root);
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
-      if (key === 'min_price' && defaultMin !== null && parseFloat(obj[key]) === defaultMin) return;
-      if (key === 'max_price' && defaultMax !== null && parseFloat(obj[key]) === defaultMax) return;
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -156,8 +121,6 @@ jQuery(function($){
     setCurrentPage($root, getCurrentPage($root));
 
     $root.on('change', '.np-orderby select', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); })
-         .on('change', '.np-price__slider input[type=range]', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
     $root.on('keyup', '.np-search', function(e){ if (e.keyCode === 13){ resetToFirstPage($root); load($root, 1, {scroll:true}); } });
     $root.on('click', '.js-np-page', function(e){
       e.preventDefault();
@@ -170,12 +133,6 @@ jQuery(function($){
     bindAllToggle($root);
 
     const url = new URL(window.location.href);
-    const pmin = url.searchParams.get('min_price');
-    const pmax = url.searchParams.get('max_price');
-    if (pmin != null){ $root.find('.np-range-min').val(pmin); }
-    if (pmax != null){ $root.find('.np-range-max').val(pmax); }
-    syncPriceUI($root);
-
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       if (!group) return;

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,4 +1,10 @@
 jQuery(function($){
+  const ORDER_DIRECTIONS = {
+    'price':'ASC',
+    'price-desc':'DESC',
+    'date':'DESC',
+    'popularity':'DESC'
+  };
   function clamp(v,a,b){ v=parseFloat(v||0); return Math.min(Math.max(v,a), b); }
   function syncPriceUI($root){
     const $wrap = $root.find('.np-price__slider'); if (!$wrap.length) return {};
@@ -9,9 +15,23 @@ jQuery(function($){
     $root.find('.np-price-min').text(vmin); $root.find('.np-price-max').text(vmax);
     return {min:vmin, max:vmax};
   }
+  function getPerPage($root){
+    return parseInt($root.data('per-page'), 10) || 12;
+  }
+  function getDefaultPerPage($root){
+    return parseInt($root.data('default-per-page'), 10) || getPerPage($root);
+  }
+  function getCurrentPage($root){
+    return parseInt($root.data('current-page'), 10) || 1;
+  }
   function buildQuery($root){
-    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce, per_page:12, page:1 };
-    data.orderby = $root.find('.np-orderby select').val();
+    const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
+    data.per_page = getPerPage($root);
+    data.page = getCurrentPage($root);
+    const orderby = $root.find('.np-orderby select').val();
+    data.orderby = orderby;
+    const orderDir = ORDER_DIRECTIONS[orderby];
+    if (orderDir){ data.order = orderDir; }
     const q = $root.find('.np-search').val(); if (q) data.s = q;
     const pr = syncPriceUI($root); if (pr.min!=null) data.min_price = pr.min; if (pr.max!=null) data.max_price = pr.max;
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
@@ -22,39 +42,62 @@ jQuery(function($){
     });
     return data;
   }
-  function toQuery(obj){
+  function toQuery($root, obj){
     const p = new URLSearchParams();
-    Object.keys(obj).forEach(k=>{ if (!['action','nonce'].includes(k) && obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]); });
+    const defaultPer = getDefaultPerPage($root);
+    Object.keys(obj).forEach(k=>{
+      if (['action','nonce'].includes(k)) return;
+      if (k === 'page' && parseInt(obj[k], 10) <= 1) return;
+      if (k === 'per_page' && parseInt(obj[k], 10) === defaultPer) return;
+      if (obj[k]!=='' && obj[k]!=null) p.set(k,obj[k]);
+    });
     return p.toString();
   }
-  function load($root){
+  function load($root, page){
+    if (typeof page !== 'undefined'){ $root.data('current-page', Math.max(1, parseInt(page, 10) || 1)); }
     const data = buildQuery($root);
-    const qs = toQuery(data);
+    const qs = toQuery($root, data);
     history.replaceState(null,'', qs ? (location.pathname+'?'+qs) : location.pathname);
+    $root.addClass('is-loading');
     $.post(NorpumpsStore.ajax_url, data, function(resp){
       if (!resp || !resp.success) return;
       $root.find('.js-np-grid').html(resp.data.html);
+      $root.find('.js-np-pagination').html(resp.data.pagination_html || '');
+      if (resp.data.page){ $root.data('current-page', resp.data.page); }
+      if (resp.data.args && resp.data.args.limit){ $root.data('per-page', parseInt(resp.data.args.limit, 10)); }
+    }).always(function(){
+      $root.removeClass('is-loading');
     });
   }
+  function resetToFirstPage($root){ $root.data('current-page', 1); }
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
-      load($root);
+      resetToFirstPage($root);
+      load($root, 1);
     });
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
       const $body = $(this).closest('.np-filter__body');
       if ($(this).is(':checked')) $body.find('.np-all-toggle').prop('checked', false);
       const anyChecked = $body.find('.np-checklist input:checked').length>0;
       if (!anyChecked) $body.find('.np-all-toggle').prop('checked', true);
-      load($root);
+      resetToFirstPage($root);
+      load($root, 1);
     });
   }
   $('.norpumps-store').each(function(){
     const $root = $(this);
-    $root.on('change', '.np-orderby select', function(){ load($root); });
-    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ load($root); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13) load($root); });
+    $root.on('change', '.np-orderby select', function(){ resetToFirstPage($root); load($root, 1); });
+    $root.on('input change', '.np-price__slider input[type=range]', function(){ syncPriceUI($root); }).on('change', '.np-price__slider input[type=range]', function(){ resetToFirstPage($root); load($root, 1); });
+    $root.on('keyup', '.np-search', function(e){ if (e.keyCode===13){ resetToFirstPage($root); load($root, 1); } });
+    $root.on('click', '.js-np-page', function(e){
+      e.preventDefault();
+      const $item = $(this).closest('.np-pagination__item');
+      if ($item.hasClass('is-disabled') || $item.hasClass('is-active')) return;
+      const page = parseInt($(this).data('page'), 10);
+      if (page){ load($root, page); }
+    });
     bindAllToggle($root);
     const url = new URL(window.location.href);
     const pmin = url.searchParams.get('min_price'), pmax = url.searchParams.get('max_price');
@@ -69,6 +112,16 @@ jQuery(function($){
         $(this).find('input').each(function(){ if (vals.includes(this.value)) this.checked = true; });
       }
     });
-    load($root);
+    const queryOrder = url.searchParams.get('orderby');
+    if (queryOrder && $root.find('.np-orderby select option[value="'+queryOrder+'"]').length){
+      $root.find('.np-orderby select').val(queryOrder);
+    }
+    const querySearch = url.searchParams.get('s');
+    if (querySearch){ $root.find('.np-search').val(querySearch); }
+    const queryPer = parseInt(url.searchParams.get('per_page'), 10);
+    if (queryPer){ $root.data('per-page', queryPer); }
+    const queryPage = parseInt(url.searchParams.get('page'), 10);
+    if (queryPage){ $root.data('current-page', queryPage); }
+    load($root, getCurrentPage($root));
   });
 });

--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -31,13 +31,7 @@ class NorPumps_Modules_Store {
                 </div>
                 <div class="np-row">
                     <label><?php esc_html_e('Filtros activos','norpumps'); ?></label>
-                    <label class="np-chip"><input type="checkbox" id="f_price" checked> <?php esc_html_e('Precio','norpumps');?></label>
                     <label class="np-chip"><input type="checkbox" id="f_cat" checked> <?php esc_html_e('Secciones de categorías','norpumps');?></label>
-                </div>
-                <div class="np-row">
-                    <label><?php esc_html_e('Rango precio (mín/máx slider visual)','norpumps'); ?></label>
-                    <input type="number" id="np_pmin" value="0" step="1">
-                    <input type="number" id="np_pmax" value="10000" step="1">
                 </div>
                 <div class="np-row">
                     <label><?php esc_html_e('Secciones (elige categoría padre)','norpumps'); ?></label>
@@ -66,18 +60,17 @@ class NorPumps_Modules_Store {
                 const cols = $('#np_cols').val()||4;
                 const perPage = $('#np_per_page').val()||12;
                 const page = $('#np_page').val()||1;
-                const filters = []; if ($('#f_price').is(':checked')) filters.push('price'); if ($('#f_cat').is(':checked')) filters.push('cat');
-                const pmin = $('#np_pmin').val()||0, pmax = $('#np_pmax').val()||10000;
+                const filters = []; if ($('#f_cat').is(':checked')) filters.push('cat');
                 const groups = [];
                 $groups.find('.np-group').each(function(){
                     const label = $(this).find('.np-group-label').val().replace(/"/g,'\\"');
                     const slug = $(this).find('.np-group-slug').val();
                     if (slug) groups.push(label+':'+slug);
                 });
-                $('#np_shortcode').text('[norpumps_store columns="'+cols+'" per_page="'+perPage+'" page="'+page+'" filters="'+filters.join(',')+'" groups="'+groups.join('|')+'" price_min="'+pmin+'" price_max="'+pmax+'" show_all="yes"]');
+                $('#np_shortcode').text('[norpumps_store columns="'+cols+'" per_page="'+perPage+'" page="'+page+'" filters="'+filters.join(',')+'" groups="'+groups.join('|')+'" show_all="yes"]');
             }
             $('#np_add_group').on('click', function(){ addGroup(); });
-            $(document).on('input change', '#np_cols, #np_per_page, #np_page, #np_pmin, #np_pmax, #f_price, #f_cat, .np-group input', updateShortcode);
+            $(document).on('input change', '#np_cols, #np_per_page, #np_page, #f_cat, .np-group input', updateShortcode);
             $(document).on('click', '.np-del', function(){ $(this).closest('.np-group').remove(); updateShortcode(); });
             $(document).on('click', '.np-search-cat', function(){
                 const $row = $(this).closest('.np-group'); const q = $row.find('.np-group-slug').val();
@@ -107,9 +100,9 @@ class NorPumps_Modules_Store {
     public function shortcode_store($atts){
         $atts = shortcode_atts([
             'columns'=>4,
-            'filters'=>'price,cat',
+            'filters'=>'cat',
             'groups'=>'', // "Label:slugPadre|Label2:slugPadre2"
-            'price_min'=>0,'price_max'=>10000,'show_all'=>'yes',
+            'show_all'=>'yes',
             'per_page'=>12,'order'=>'menu_order title','page'=>1,
         ], $atts, 'norpumps_store');
         $columns = max(2, min(6, intval($atts['columns'])));
@@ -120,15 +113,8 @@ class NorPumps_Modules_Store {
             if (count($parts)==2){ $label = sanitize_text_field($parts[0]); $slug = sanitize_title($parts[1]); if ($slug) $groups[]=['label'=>$label?:$slug,'slug'=>$slug]; }
         }
         $default_page = max(1, intval($atts['page']));
-        $default_min_price = floatval($atts['price_min']);
-        $default_max_price = floatval($atts['price_max']);
         $requested_per_page = max(1, min(60, intval(isset($_GET['per_page']) ? $_GET['per_page'] : $per_page)));
         $requested_page = max(1, intval(isset($_GET['page']) ? $_GET['page'] : $default_page));
-        $requested_min_price = isset($_GET['min_price']) ? floatval($_GET['min_price']) : $default_min_price;
-        $requested_max_price = isset($_GET['max_price']) ? floatval($_GET['max_price']) : $default_max_price;
-        if ($requested_min_price > $requested_max_price){ $tmp = $requested_min_price; $requested_min_price = $requested_max_price; $requested_max_price = $tmp; }
-        $requested_min_price = max($default_min_price, min($default_max_price, $requested_min_price));
-        $requested_max_price = max($requested_min_price, min($default_max_price, $requested_max_price));
         $search_query = sanitize_text_field(norpumps_array_get($_GET,'s',''));
         $allowed_orderby = ['menu_order title','price','price-desc','date','popularity'];
         $orderby_query = sanitize_text_field(norpumps_array_get($_GET,'orderby','menu_order title'));
@@ -184,9 +170,6 @@ class NorPumps_Modules_Store {
                 }
             }
         }
-        $min = isset($_REQUEST['min_price']) ? floatval($_REQUEST['min_price']) : null;
-        $max = isset($_REQUEST['max_price']) ? floatval($_REQUEST['max_price']) : null;
-        if ($min !== null || $max !== null){ $args['min_price']=$min; $args['max_price']=$max; }
         $search = sanitize_text_field(norpumps_array_get($_REQUEST,'s',''));
         if ($search !== ''){ $args['s'] = $search; }
         if (count($tax_query)>1) $args['tax_query']=$tax_query;

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -5,7 +5,7 @@ $price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="1">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,24 +1,31 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$price_min = isset($atts['price_min']) ? floatval($atts['price_min']) : 0;
-$price_max = isset($atts['price_max']) ? floatval($atts['price_max']) : 10000;
+$default_min = isset($default_min_price) ? floatval($default_min_price) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
+$default_max = isset($default_max_price) ? floatval($default_max_price) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
+$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $default_min;
+$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $default_max;
+$current_per_page = isset($requested_per_page) ? intval($requested_per_page) : (isset($per_page) ? intval($per_page) : 12);
+$current_page = isset($requested_page) ? intval($requested_page) : 1;
+$default_page_attr = isset($default_page) ? intval($default_page) : 1;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
+$search_value = isset($search_query) ? $search_query : '';
+$orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="1">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($default_min); ?>" data-default-max-price="<?php echo esc_attr($default_max); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
       <select class="np-orderby">
-        <option value="menu_order title"><?php esc_html_e('Predeterminado','norpumps'); ?></option>
-        <option value="price"><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
-        <option value="price-desc"><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
-        <option value="date"><?php esc_html_e('Novedades','norpumps'); ?></option>
-        <option value="popularity"><?php esc_html_e('Popularidad','norpumps'); ?></option>
+        <option value="menu_order title" <?php selected($orderby_value, 'menu_order title'); ?>><?php esc_html_e('Predeterminado','norpumps'); ?></option>
+        <option value="price" <?php selected($orderby_value, 'price'); ?>><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
+        <option value="price-desc" <?php selected($orderby_value, 'price-desc'); ?>><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
+        <option value="date" <?php selected($orderby_value, 'date'); ?>><?php esc_html_e('Novedades','norpumps'); ?></option>
+        <option value="popularity" <?php selected($orderby_value, 'popularity'); ?>><?php esc_html_e('Popularidad','norpumps'); ?></option>
       </select>
     </div>
     <div class="norpumps-store__search">
-      <input type="search" class="np-search" placeholder="<?php esc_attr_e('Buscar productos…','norpumps'); ?>">
+      <input type="search" class="np-search" value="<?php echo esc_attr($search_value); ?>" placeholder="<?php esc_attr_e('Buscar productos…','norpumps'); ?>">
     </div>
   </div>
 
@@ -29,14 +36,14 @@ if (!isset($filters_arr)) $filters_arr = [];
         <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
         <div class="np-filter__body">
           <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($price_min); ?>" data-max="<?php echo esc_attr($price_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($price_min); ?>" max="<?php echo esc_attr($price_max); ?>" value="<?php echo esc_attr($price_max); ?>">
+            <div class="np-price__slider" data-min="<?php echo esc_attr($default_min); ?>" data-max="<?php echo esc_attr($default_max); ?>">
+              <input type="range" class="np-range-min" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_min); ?>">
+              <input type="range" class="np-range-max" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_max); ?>">
             </div>
             <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($price_min); ?></span>
+              <span class="np-price-min"><?php echo esc_html($current_min); ?></span>
               <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($price_max); ?></span>
+              <span class="np-price-max"><?php echo esc_html($current_max); ?></span>
             </div>
           </div>
         </div>

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -1,9 +1,5 @@
 <?php if (!defined('ABSPATH')) { exit; } ?>
 <?php
-$default_min = isset($default_min_price) ? floatval($default_min_price) : (isset($atts['price_min']) ? floatval($atts['price_min']) : 0);
-$default_max = isset($default_max_price) ? floatval($default_max_price) : (isset($atts['price_max']) ? floatval($atts['price_max']) : 10000);
-$current_min = isset($requested_min_price) ? floatval($requested_min_price) : $default_min;
-$current_max = isset($requested_max_price) ? floatval($requested_max_price) : $default_max;
 $current_per_page = isset($requested_per_page) ? intval($requested_per_page) : (isset($per_page) ? intval($per_page) : 12);
 $current_page = isset($requested_page) ? intval($requested_page) : 1;
 $default_page_attr = isset($default_page) ? intval($default_page) : 1;
@@ -12,7 +8,7 @@ $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-min-price="<?php echo esc_attr($default_min); ?>" data-default-max-price="<?php echo esc_attr($default_max); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -31,25 +27,6 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
-      <?php if (in_array('price',$filters_arr)): ?>
-      <div class="np-filter">
-        <div class="np-filter__head"><?php esc_html_e('PRECIO','norpumps'); ?></div>
-        <div class="np-filter__body">
-          <div class="np-price">
-            <div class="np-price__slider" data-min="<?php echo esc_attr($default_min); ?>" data-max="<?php echo esc_attr($default_max); ?>">
-              <input type="range" class="np-range-min" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_min); ?>">
-              <input type="range" class="np-range-max" min="<?php echo esc_attr($default_min); ?>" max="<?php echo esc_attr($default_max); ?>" value="<?php echo esc_attr($current_max); ?>">
-            </div>
-            <div class="np-price__labels">
-              <span class="np-price-min"><?php echo esc_html($current_min); ?></span>
-              <span>—</span>
-              <span class="np-price-max"><?php echo esc_html($current_max); ?></span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <?php endif; ?>
-
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/norpumps.php
+++ b/norpumps.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: NorPumps Suite
- * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
+ * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
  * Version: 1.2.2
  * Author: Alfonso (fiverr)
  * Requires at least: 6.0

--- a/norpumps.php
+++ b/norpumps.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * Plugin Name: NorPumps Suite
- * Description: v1.2.1 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
- * Version: 1.2.1
+ * Description: v1.2.2 — Tienda solo con categorías. Padre = título; hijas = checkboxes. AJAX + URL amigables. Slider precio. Admin con autocompletar. (Fix JSON/func redeclare) + módulo techsheet
+ * Version: 1.2.2
  * Author: Alfonso (fiverr)
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: norpumps
  */
 if (!defined('ABSPATH')) { exit; }
-define('NORPUMPS_VERSION', '1.2.1');
+define('NORPUMPS_VERSION', '1.2.2');
 define('NORPUMPS_PATH', plugin_dir_path(__FILE__));
 define('NORPUMPS_URL', plugin_dir_url(__FILE__));
 spl_autoload_register(function($class){


### PR DESCRIPTION
## Summary
- remove the price filter controls from the shortcode generator and storefront template
- delete all supporting PHP and JavaScript logic tied to min/max price filtering
- clean up styles and plugin description references to the removed price filter

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f02da01cd0833094035085f877e039