### PR TITLE
Add combined price range filtering UI

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,6 +13,23 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
+.norpumps-filters .np-filter--price .np-filter__body{ padding:18px 18px 20px; background:linear-gradient(160deg,#f2f8f9 0%,#fff 65%); border:1px solid rgba(8,54,64,0.08); border-radius:0 0 16px 16px; box-shadow:0 12px 30px rgba(8,54,64,0.08); }
+.norpumps-filters .np-filter--price .np-filter__head{ background:#083640; letter-spacing:.04em; }
+.np-price{ display:flex; flex-direction:column; gap:14px; }
+.np-price__values{ display:flex; justify-content:space-between; font-weight:700; color:#083640; font-size:15px; }
+.np-price__slider{ position:relative; height:44px; display:flex; align-items:center; padding:16px 4px; }
+.np-price__track{ position:absolute; left:4px; right:4px; top:50%; transform:translateY(-50%); height:8px; border-radius:999px; background:#083640; opacity:.32; z-index:1; }
+.np-price__range{ -webkit-appearance:none; appearance:none; width:100%; position:absolute; left:0; right:0; height:0; pointer-events:auto; background:none; z-index:2; }
+.np-price__range--min{ z-index:3; }
+.np-price__range--max{ z-index:4; }
+.np-price__range::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:20px; height:20px; border-radius:50%; background:#083640; border:2px solid #fff; box-shadow:0 4px 10px rgba(8,54,64,0.35); cursor:pointer; pointer-events:auto; transition:transform .15s ease, box-shadow .15s ease; }
+.np-price__range::-moz-range-thumb{ width:20px; height:20px; border-radius:50%; background:#083640; border:2px solid #fff; box-shadow:0 4px 10px rgba(8,54,64,0.35); cursor:pointer; pointer-events:auto; transition:transform .15s ease, box-shadow .15s ease; }
+.np-price__range::-webkit-slider-thumb:hover, .np-price__range::-moz-range-thumb:hover{ transform:scale(1.05); box-shadow:0 6px 16px rgba(8,54,64,0.4); }
+.np-price__range:focus::-webkit-slider-thumb{ outline:3px solid rgba(8,54,64,0.4); outline-offset:2px; }
+.np-price__range:focus::-moz-range-thumb{ outline:3px solid rgba(8,54,64,0.4); outline-offset:2px; }
+.np-price__range::-webkit-slider-runnable-track{ height:0; }
+.np-price__range::-moz-range-track{ height:0; background:transparent; }
+.np-price__hint{ margin:0; font-size:13px; color:#39575d; line-height:1.4; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -8,6 +8,9 @@ jQuery(function($){
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
+  function nearlyEqual(a, b){
+    return Math.abs(parseFloat(a) - parseFloat(b)) < 0.0001;
+  }
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
     return isFiniteNumber(val) && val > 0 ? val : 12;
@@ -38,6 +41,28 @@ jQuery(function($){
     setCurrentPage($root, fallback);
     return fallback;
   }
+  function setPriceDefaults($root, defaults){
+    if (!defaults) return;
+    if (isFiniteNumber(defaults.min)) $root.data('priceDefaultMin', defaults.min);
+    if (isFiniteNumber(defaults.max)) $root.data('priceDefaultMax', defaults.max);
+  }
+  function setPriceCurrent($root, current){
+    if (!current) return;
+    if (isFiniteNumber(current.min)) $root.data('priceCurrentMin', current.min);
+    if (isFiniteNumber(current.max)) $root.data('priceCurrentMax', current.max);
+  }
+  function getPriceDefaults($root){
+    const min = parseFloat($root.data('priceDefaultMin'));
+    const max = parseFloat($root.data('priceDefaultMax'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)) return null;
+    return { min, max };
+  }
+  function getPriceCurrent($root){
+    const min = parseFloat($root.data('priceCurrentMin'));
+    const max = parseFloat($root.data('priceCurrentMax'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)) return null;
+    return { min, max };
+  }
   function buildQuery($root){
     const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
     data.per_page = getPerPage($root);
@@ -56,17 +81,30 @@ jQuery(function($){
         data['cat_'+group] = vals.join(',');
       }
     });
+    const priceCurrent = getPriceCurrent($root);
+    const priceDefaults = getPriceDefaults($root);
+    if (priceCurrent){
+      const minChanged = !priceDefaults || !nearlyEqual(priceCurrent.min, priceDefaults.min);
+      const maxChanged = !priceDefaults || !nearlyEqual(priceCurrent.max, priceDefaults.max);
+      if (minChanged || maxChanged){
+        data.price_min = priceCurrent.min;
+        data.price_max = priceCurrent.max;
+      }
+    }
     return data;
   }
   function toQuery($root, obj){
     const params = new URLSearchParams();
     const defaultPer = getDefaultPerPage($root);
     const defaultPage = getDefaultPage($root);
+    const priceDefaults = getPriceDefaults($root);
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
+      if (priceDefaults && key === 'price_min' && nearlyEqual(parseFloat(obj[key]), priceDefaults.min)) return;
+      if (priceDefaults && key === 'price_max' && nearlyEqual(parseFloat(obj[key]), priceDefaults.max)) return;
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -114,6 +152,104 @@ jQuery(function($){
       load($root, 1, {scroll:true});
     });
   }
+  function formatPrice(value, symbol, locale){
+    const loc = locale || (typeof NorpumpsStore.locale !== 'undefined' ? NorpumpsStore.locale : 'es-ES');
+    try {
+      const formatter = new Intl.NumberFormat(loc, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+      return (symbol || '') + formatter.format(value);
+    } catch (e){
+      return (symbol || '') + value;
+    }
+  }
+  function initPriceFilter($root, url){
+    const $filter = $root.find('[data-price-filter]');
+    if (!$filter.length) return;
+    const limitMin = parseFloat($filter.data('min'));
+    const limitMax = parseFloat($filter.data('max'));
+    const defaultMin = parseFloat($filter.data('defaultMin'));
+    const defaultMax = parseFloat($filter.data('defaultMax'));
+    const symbol = $filter.data('symbol') || '';
+    const locale = $filter.data('locale') || null;
+    const $minInput = $filter.find('.np-price__range--min');
+    const $maxInput = $filter.find('.np-price__range--max');
+    const $track = $filter.find('.np-price__track');
+    const $minDisplay = $filter.find('[data-price-role="min"]');
+    const $maxDisplay = $filter.find('[data-price-role="max"]');
+    const rangeTotal = limitMax - limitMin;
+    let scheduleId = null;
+    setPriceDefaults($root, { min: defaultMin, max: defaultMax });
+
+    function clamp(value, min, max){
+      let v = parseFloat(value);
+      if (!isFiniteNumber(v)) v = min;
+      if (v < min) v = min;
+      if (v > max) v = max;
+      return v;
+    }
+    function updateTrack(minValue, maxValue){
+      if (!$track.length) return;
+      if (!isFiniteNumber(rangeTotal) || rangeTotal <= 0){
+        $track.css('background', '#083640');
+        return;
+      }
+      const start = Math.max(0, Math.min(100, ((minValue - limitMin) / rangeTotal) * 100));
+      const end = Math.max(0, Math.min(100, ((maxValue - limitMin) / rangeTotal) * 100));
+      $track.css('background', `linear-gradient(to right, #d1dee3 0%, #d1dee3 ${start}%, #083640 ${start}%, #083640 ${end}%, #d1dee3 ${end}%, #d1dee3 100%)`);
+    }
+    function setValues(minVal, maxVal, origin){
+      let minValue = clamp(minVal, limitMin, limitMax);
+      let maxValue = clamp(maxVal, limitMin, limitMax);
+      if (minValue > maxValue){
+        if (origin === 'min'){
+          minValue = maxValue;
+        } else {
+          maxValue = minValue;
+        }
+      }
+      if ($minInput.length) $minInput.val(minValue);
+      if ($maxInput.length) $maxInput.val(maxValue);
+      $minDisplay.text(formatPrice(minValue, symbol, locale));
+      $maxDisplay.text(formatPrice(maxValue, symbol, locale));
+      updateTrack(minValue, maxValue);
+      setPriceCurrent($root, { min: minValue, max: maxValue });
+    }
+    function debounceLoad(){
+      if (scheduleId){
+        clearTimeout(scheduleId);
+      }
+      scheduleId = setTimeout(function(){
+        resetToFirstPage($root);
+        load($root, 1, {scroll:true});
+      }, 220);
+    }
+    function handleMinChange(){
+      const other = parseFloat($maxInput.val());
+      const value = parseFloat(this.value);
+      setValues(value, other, 'min');
+      debounceLoad();
+    }
+    function handleMaxChange(){
+      const other = parseFloat($minInput.val());
+      const value = parseFloat(this.value);
+      setValues(other, value, 'max');
+      debounceLoad();
+    }
+    if ($minInput.length){
+      $minInput.on('input change', handleMinChange);
+    }
+    if ($maxInput.length){
+      $maxInput.on('input change', handleMaxChange);
+    }
+    let startMin = defaultMin;
+    let startMax = defaultMax;
+    if (url instanceof URL){
+      const queryMin = parseFloat(url.searchParams.get('price_min'));
+      const queryMax = parseFloat(url.searchParams.get('price_max'));
+      if (isFiniteNumber(queryMin)) startMin = queryMin;
+      if (isFiniteNumber(queryMax)) startMax = queryMax;
+    }
+    setValues(startMin, startMax);
+  }
 
   $('.norpumps-store').each(function(){
     const $root = $(this);
@@ -133,6 +269,7 @@ jQuery(function($){
     bindAllToggle($root);
 
     const url = new URL(window.location.href);
+    initPriceFilter($root, url);
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       if (!group) return;

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,18 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_min_limit = isset($price_min) ? floatval($price_min) : 0;
+$price_max_limit = isset($price_max) ? floatval($price_max) : 0;
+$price_step_value = isset($price_step) ? floatval($price_step) : 1;
+$price_locale = function_exists('determine_locale') ? determine_locale() : get_locale();
+$currency_symbol = function_exists('get_woocommerce_currency_symbol') ? html_entity_decode(get_woocommerce_currency_symbol(), ENT_QUOTES, get_bloginfo('charset')) : get_option('woocommerce_currency');
+$price_formatter = function_exists('wc_price') ? function($value){ return wp_strip_all_tags(wc_price($value)); } : function($value) use ($currency_symbol){
+    $symbol = is_string($currency_symbol) ? trim($currency_symbol) : '';
+    $formatted = number_format_i18n($value, 0);
+    return $symbol ? $symbol.' '.$formatted : $formatted;
+};
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-default-min="<?php echo esc_attr($price_min_limit); ?>" data-price-default-max="<?php echo esc_attr($price_max_limit); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +37,25 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (in_array('price',$filters_arr)): ?>
+        <div class="np-filter np-filter--price" data-price-filter data-min="<?php echo esc_attr($price_min_limit); ?>" data-max="<?php echo esc_attr($price_max_limit); ?>" data-default-min="<?php echo esc_attr($price_min_limit); ?>" data-default-max="<?php echo esc_attr($price_max_limit); ?>" data-step="<?php echo esc_attr($price_step_value); ?>" data-symbol="<?php echo esc_attr($currency_symbol); ?>" data-locale="<?php echo esc_attr($price_locale); ?>">
+          <div class="np-filter__head"><?php esc_html_e('Rango de precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price">
+              <div class="np-price__values">
+                <span class="np-price__value" data-price-role="min"><?php echo esc_html(call_user_func($price_formatter, $price_min_limit)); ?></span>
+                <span class="np-price__value" data-price-role="max"><?php echo esc_html(call_user_func($price_formatter, $price_max_limit)); ?></span>
+              </div>
+              <div class="np-price__slider">
+                <div class="np-price__track"></div>
+                <input type="range" class="np-price__range np-price__range--min" min="<?php echo esc_attr($price_min_limit); ?>" max="<?php echo esc_attr($price_max_limit); ?>" step="<?php echo esc_attr($price_step_value); ?>" value="<?php echo esc_attr($price_min_limit); ?>">
+                <input type="range" class="np-price__range np-price__range--max" min="<?php echo esc_attr($price_min_limit); ?>" max="<?php echo esc_attr($price_max_limit); ?>" step="<?php echo esc_attr($price_step_value); ?>" value="<?php echo esc_attr($price_max_limit); ?>">
+              </div>
+              <p class="np-price__hint"><?php esc_html_e('Ajusta los controles para acotar los resultados por precio.','norpumps'); ?></p>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add a toggleable price range filter to the shortcode generator and expose price defaults in the store layout
- style and implement a dual-handle slider that syncs with AJAX pagination, search, and category filters
- pipe selected price bounds into the WooCommerce query so price can be combined with other filters

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f04a3046b48330af6abd669e40cdda