### PR TITLE
Add price range filter to NorPumps store module

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -1,5 +1,5 @@
 /* v1.2.1 — estilo similar al screenshot */
-.norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; }
+.norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; --np-price-accent:#083640; }
 .norpumps-store a { color:#0a66a1; text-decoration:none; }
 .norpumps-store .norpumps-store__header{ display:flex; justify-content:space-between; align-items:center; margin:10px 0 20px; }
 .norpumps-store .np-orderby select, .norpumps-store .np-search input{ padding:8px 10px; border:1px solid #d7dee2; border-radius:6px; background:#fff; }
@@ -9,6 +9,24 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.norpumps-filters .np-filter--price .np-filter__head{ background:var(--np-price-accent); }
+.norpumps-filters .np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:14px; }
+.np-price-range{ display:flex; flex-direction:column; gap:14px; }
+.np-price-range__header{ display:flex; align-items:center; justify-content:space-between; gap:12px; font-weight:600; color:var(--np-price-accent); }
+.np-price-value{ font-size:14px; }
+.np-price-reset{ background:transparent; border:1px solid var(--np-price-accent); color:var(--np-price-accent); border-radius:999px; padding:6px 14px; font-size:13px; font-weight:600; cursor:pointer; transition:all .2s ease; }
+.np-price-reset:hover{ background:var(--np-price-accent); color:#fff; }
+.np-price-range__sliders{ position:relative; height:38px; }
+.np-price-range__sliders::before{ content:""; position:absolute; top:50%; left:0; right:0; transform:translateY(-50%); height:6px; border-radius:999px; background:#d7dee2; }
+.np-price-progress{ position:absolute; top:50%; left:0; right:0; transform:translateY(-50%); height:6px; border-radius:999px; background:var(--np-price-accent); box-shadow:0 4px 10px rgba(8,54,64,0.25); z-index:1; }
+.np-price-input{ position:absolute; left:0; right:0; width:100%; height:38px; margin:0; padding:0; appearance:none; background:none; pointer-events:none; z-index:2; }
+.np-price-input::-webkit-slider-thumb{ appearance:none; pointer-events:auto; width:18px; height:18px; border-radius:50%; background:var(--np-price-accent); border:2px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); cursor:pointer; }
+.np-price-input::-webkit-slider-runnable-track{ height:6px; background:transparent; }
+.np-price-input::-moz-range-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:var(--np-price-accent); border:2px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); cursor:pointer; }
+.np-price-input::-moz-range-track{ height:6px; background:transparent; }
+.np-price-input::-ms-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:var(--np-price-accent); border:2px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); cursor:pointer; }
+.np-price-input::-ms-track{ height:6px; background:transparent; border-color:transparent; color:transparent; }
+.np-price-input::-ms-fill-lower, .np-price-input::-ms-fill-upper{ background:transparent; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
@@ -44,6 +62,7 @@
 .norpumps-admin .np-chip{ display:inline-flex; align-items:center; gap:6px; background:#eef7f8; padding:6px 10px; border-radius:999px; margin-right:8px; }
 .norpumps-admin .np-group{ display:flex; gap:10px; align-items:center; margin:8px 0; }
 .norpumps-admin .np-group input{ padding:6px 8px; }
+.norpumps-admin .np-row--price input{ max-width:160px; }
 .norpumps-admin .np-autocomplete{ position:relative; background:#fff; border:1px solid #ccd; padding:6px; border-radius:8px; margin-top:6px; max-width:520px; }
 .norpumps-admin .np-autocomplete .np-opt{ padding:6px 8px; cursor:pointer; }
 .norpumps-admin .np-autocomplete .np-opt:hover{ background:#f5f8fb; }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -6,6 +6,8 @@ jQuery(function($){
     'popularity':'DESC'
   };
   const SCROLL_OFFSET = 120;
+  const PRICE_PROGRESS_SELECTOR = '.np-price-progress';
+  let cachedPriceFormatter = null;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
   function getDefaultPerPage($root){
@@ -38,6 +40,84 @@ jQuery(function($){
     setCurrentPage($root, fallback);
     return fallback;
   }
+  function getPriceBounds($root){
+    if (!$root.data('priceEnabled')) return null;
+    const min = parseFloat($root.data('priceMin'));
+    const max = parseFloat($root.data('priceMax'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max) || max <= min){
+      return null;
+    }
+    return { min, max };
+  }
+  function getPriceFormatter(){
+    if (cachedPriceFormatter) return cachedPriceFormatter;
+    const decimals = parseInt(NorpumpsStore.price_decimals, 10);
+    const fractionDigits = isFiniteNumber(decimals) ? Math.max(0, decimals) : 0;
+    try {
+      cachedPriceFormatter = new Intl.NumberFormat(undefined, {
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits
+      });
+    } catch (err){
+      cachedPriceFormatter = {
+        format: function(value){
+          const num = Number(value);
+          if (!isFiniteNumber(num)) return '0';
+          return num.toFixed(fractionDigits);
+        }
+      };
+    }
+    return cachedPriceFormatter;
+  }
+  function formatMoney(value){
+    const formatter = getPriceFormatter();
+    const symbol = NorpumpsStore.currency_symbol || '$';
+    const number = isFiniteNumber(value) ? value : 0;
+    if (typeof formatter.format === 'function'){
+      return symbol + ' ' + formatter.format(number);
+    }
+    return symbol + ' ' + Number(number).toFixed(0);
+  }
+  function updatePriceProgress($root, minValue, maxValue, bounds){
+    const range = bounds.max - bounds.min;
+    if (range <= 0) return;
+    const leftPercent = ((minValue - bounds.min) / range) * 100;
+    const rightPercent = ((maxValue - bounds.min) / range) * 100;
+    const $progress = $root.find(PRICE_PROGRESS_SELECTOR);
+    if ($progress.length){
+      $progress.css({ left: leftPercent + '%', right: (100 - rightPercent) + '%' });
+    }
+  }
+  function setPriceRange($root, minValue, maxValue){
+    const bounds = getPriceBounds($root);
+    if (!bounds) return;
+    let min = isFiniteNumber(minValue) ? minValue : bounds.min;
+    let max = isFiniteNumber(maxValue) ? maxValue : bounds.max;
+    min = Math.max(bounds.min, Math.min(min, bounds.max));
+    max = Math.max(bounds.min, Math.min(max, bounds.max));
+    if (min > max){
+      const swap = min;
+      min = max;
+      max = swap;
+    }
+    $root.data('priceCurrentMin', min);
+    $root.data('priceCurrentMax', max);
+    $root.find('.np-price-value--min').text(formatMoney(min));
+    $root.find('.np-price-value--max').text(formatMoney(max));
+    $root.find('.np-price-input[data-handle="min"]').val(min);
+    $root.find('.np-price-input[data-handle="max"]').val(max);
+    updatePriceProgress($root, min, max, bounds);
+  }
+  function getCurrentPriceRange($root){
+    const bounds = getPriceBounds($root);
+    if (!bounds) return null;
+    const min = parseFloat($root.data('priceCurrentMin'));
+    const max = parseFloat($root.data('priceCurrentMax'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)){
+      return { min: bounds.min, max: bounds.max };
+    }
+    return { min, max };
+  }
   function buildQuery($root){
     const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
     data.per_page = getPerPage($root);
@@ -48,6 +128,11 @@ jQuery(function($){
     if (orderDir){ data.order = orderDir; }
     const search = $root.find('.np-search').val();
     if (search){ data.s = search; }
+    const priceRange = getCurrentPriceRange($root);
+    if (priceRange){
+      data.price_min = priceRange.min;
+      data.price_max = priceRange.max;
+    }
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
@@ -67,6 +152,14 @@ jQuery(function($){
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
+      if (key === 'price_min' || key === 'price_max'){
+        const bounds = getPriceBounds($root);
+        if (!bounds) return;
+        const value = parseFloat(obj[key]);
+        if (!isFiniteNumber(value)) return;
+        if (key === 'price_min' && Math.abs(value - bounds.min) < 1e-6) return;
+        if (key === 'price_max' && Math.abs(value - bounds.max) < 1e-6) return;
+      }
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -114,6 +207,44 @@ jQuery(function($){
       load($root, 1, {scroll:true});
     });
   }
+  function bindPriceFilter($root){
+    const bounds = getPriceBounds($root);
+    if (!bounds) return;
+    $root.on('input', '.np-price-input', function(){
+      const handle = $(this).data('handle');
+      const value = parseFloat(this.value);
+      const current = getCurrentPriceRange($root) || bounds;
+      if (handle === 'min'){
+        setPriceRange($root, value, current.max);
+      } else {
+        setPriceRange($root, current.min, value);
+      }
+    });
+    $root.on('change', '.np-price-input', function(){
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+    $root.on('click', '.np-price-reset', function(e){
+      e.preventDefault();
+      setPriceRange($root, bounds.min, bounds.max);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+  }
+  function initializePriceFilter($root, url){
+    const bounds = getPriceBounds($root);
+    if (!bounds) return;
+    const defaultMin = parseFloat($root.data('priceCurrentMin'));
+    const defaultMax = parseFloat($root.data('priceCurrentMax'));
+    let min = isFiniteNumber(defaultMin) ? defaultMin : bounds.min;
+    let max = isFiniteNumber(defaultMax) ? defaultMax : bounds.max;
+    const queryMin = parseFloat(url.searchParams.get('price_min'));
+    const queryMax = parseFloat(url.searchParams.get('price_max'));
+    if (isFiniteNumber(queryMin)){ min = queryMin; }
+    if (isFiniteNumber(queryMax)){ max = queryMax; }
+    setPriceRange($root, min, max);
+    bindPriceFilter($root);
+  }
 
   $('.norpumps-store').each(function(){
     const $root = $(this);
@@ -133,6 +264,8 @@ jQuery(function($){
     bindAllToggle($root);
 
     const url = new URL(window.location.href);
+    initializePriceFilter($root, url);
+
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       if (!group) return;

--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -32,6 +32,12 @@ class NorPumps_Modules_Store {
                 <div class="np-row">
                     <label><?php esc_html_e('Filtros activos','norpumps'); ?></label>
                     <label class="np-chip"><input type="checkbox" id="f_cat" checked> <?php esc_html_e('Secciones de categorías','norpumps');?></label>
+                    <label class="np-chip"><input type="checkbox" id="f_price"> <?php esc_html_e('Filtro de precios','norpumps');?></label>
+                </div>
+                <div class="np-row np-row--price">
+                    <label><?php esc_html_e('Rango de precios (mínimo / máximo)','norpumps'); ?></label>
+                    <input type="number" id="np_price_min" value="0" min="0" step="1">
+                    <input type="number" id="np_price_max" value="10000" min="0" step="1">
                 </div>
                 <div class="np-row">
                     <label><?php esc_html_e('Secciones (elige categoría padre)','norpumps'); ?></label>
@@ -60,17 +66,24 @@ class NorPumps_Modules_Store {
                 const cols = $('#np_cols').val()||4;
                 const perPage = $('#np_per_page').val()||12;
                 const page = $('#np_page').val()||1;
-                const filters = []; if ($('#f_cat').is(':checked')) filters.push('cat');
+                const filters = [];
+                if ($('#f_cat').is(':checked')) filters.push('cat');
+                if ($('#f_price').is(':checked')) filters.push('price');
                 const groups = [];
                 $groups.find('.np-group').each(function(){
                     const label = $(this).find('.np-group-label').val().replace(/"/g,'\\"');
                     const slug = $(this).find('.np-group-slug').val();
                     if (slug) groups.push(label+':'+slug);
                 });
-                $('#np_shortcode').text('[norpumps_store columns="'+cols+'" per_page="'+perPage+'" page="'+page+'" filters="'+filters.join(',')+'" groups="'+groups.join('|')+'" show_all="yes"]');
+                const minPrice = Math.max(0, parseFloat($('#np_price_min').val()) || 0);
+                $('#np_price_min').val(minPrice);
+                let maxPrice = Math.max(minPrice + 1, parseFloat($('#np_price_max').val()) || minPrice + 1);
+                $('#np_price_max').val(maxPrice);
+                const shortcode = '[norpumps_store columns="'+cols+'" per_page="'+perPage+'" page="'+page+'" filters="'+filters.join(',')+'" groups="'+groups.join('|')+'" price_min="'+minPrice+'" price_max="'+maxPrice+'" show_all="yes"]';
+                $('#np_shortcode').text(shortcode);
             }
             $('#np_add_group').on('click', function(){ addGroup(); });
-            $(document).on('input change', '#np_cols, #np_per_page, #np_page, #f_cat, .np-group input', updateShortcode);
+            $(document).on('input change', '#np_cols, #np_per_page, #np_page, #f_cat, #f_price, #np_price_min, #np_price_max, .np-group input', updateShortcode);
             $(document).on('click', '.np-del', function(){ $(this).closest('.np-group').remove(); updateShortcode(); });
             $(document).on('click', '.np-search-cat', function(){
                 const $row = $(this).closest('.np-group'); const q = $row.find('.np-group-slug').val();
@@ -104,6 +117,8 @@ class NorPumps_Modules_Store {
             'groups'=>'', // "Label:slugPadre|Label2:slugPadre2"
             'show_all'=>'yes',
             'per_page'=>12,'order'=>'menu_order title','page'=>1,
+            'price_min'=>0,
+            'price_max'=>10000,
         ], $atts, 'norpumps_store');
         $columns = max(2, min(6, intval($atts['columns'])));
         $per_page = max(1, min(60, intval($atts['per_page'])));
@@ -121,11 +136,34 @@ class NorPumps_Modules_Store {
         if (!in_array($orderby_query, $allowed_orderby, true)){
             $orderby_query = 'menu_order title';
         }
+        $filters_arr = array_filter(array_map('trim', explode(',', $atts['filters'])));
+        $price_filter_enabled = in_array('price', $filters_arr, true);
+        $price_min_attr = max(0.0, floatval($atts['price_min']));
+        $price_max_attr = floatval($atts['price_max']);
+        if ($price_max_attr <= $price_min_attr){
+            $price_max_attr = $price_min_attr + 1;
+        }
+        $price_current_min = $price_min_attr;
+        $price_current_max = $price_max_attr;
+        if ($price_filter_enabled){
+            $requested_min_price = norpumps_array_get($_GET, 'price_min', null);
+            $requested_max_price = norpumps_array_get($_GET, 'price_max', null);
+            if ($requested_min_price !== null && $requested_min_price !== ''){
+                $price_current_min = max($price_min_attr, min($price_max_attr, floatval($requested_min_price)));
+            }
+            if ($requested_max_price !== null && $requested_max_price !== ''){
+                $price_current_max = max($price_min_attr, min($price_max_attr, floatval($requested_max_price)));
+            }
+            if ($price_current_min > $price_current_max){
+                $tmp = $price_current_min;
+                $price_current_min = $price_current_max;
+                $price_current_max = $tmp;
+            }
+        }
         wp_enqueue_script('wc-add-to-cart');
         wp_enqueue_script('wc-cart-fragments');
         wp_enqueue_style('woocommerce-general');
         ob_start();
-        $filters_arr = array_filter(array_map('trim', explode(',', $atts['filters'])));
         include __DIR__.'/templates/store.php';
         return ob_get_clean();
     }
@@ -169,6 +207,19 @@ class NorPumps_Modules_Store {
                     $tax_query[] = ['taxonomy'=>'product_cat','field'=>'slug','terms'=>$slugs,'include_children'=>true,'operator'=>'IN'];
                 }
             }
+        }
+        $has_min_price = isset($_REQUEST['price_min']) && $_REQUEST['price_min'] !== '';
+        $has_max_price = isset($_REQUEST['price_max']) && $_REQUEST['price_max'] !== '';
+        if ($has_min_price || $has_max_price){
+            $min_price = $has_min_price && is_numeric($_REQUEST['price_min']) ? floatval($_REQUEST['price_min']) : null;
+            $max_price = $has_max_price && is_numeric($_REQUEST['price_max']) ? floatval($_REQUEST['price_max']) : null;
+            if ($min_price !== null && $max_price !== null && $min_price > $max_price){
+                $tmp = $min_price;
+                $min_price = $max_price;
+                $max_price = $tmp;
+            }
+            if ($min_price !== null){ $args['min_price'] = max(0, $min_price); }
+            if ($max_price !== null){ $args['max_price'] = max(0, $max_price); }
         }
         $search = sanitize_text_field(norpumps_array_get($_REQUEST,'s',''));
         if ($search !== ''){ $args['s'] = $search; }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,17 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_filter_enabled = isset($price_filter_enabled) ? (bool)$price_filter_enabled : false;
+$price_min_attr = isset($price_min_attr) ? floatval($price_min_attr) : 0.0;
+$price_max_attr = isset($price_max_attr) ? floatval($price_max_attr) : 0.0;
+$price_current_min = isset($price_current_min) ? floatval($price_current_min) : $price_min_attr;
+$price_current_max = isset($price_current_max) ? floatval($price_current_max) : $price_max_attr;
+$currency_symbol = function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$';
+$price_decimals = function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : 0;
+$price_min_label = $currency_symbol . ' ' . number_format_i18n($price_current_min, $price_decimals);
+$price_max_label = $currency_symbol . ' ' . number_format_i18n($price_current_max, $price_decimals);
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-enabled="<?php echo esc_attr($price_filter_enabled ? '1' : '0'); ?>" data-price-min="<?php echo esc_attr($price_min_attr); ?>" data-price-max="<?php echo esc_attr($price_max_attr); ?>" data-price-current-min="<?php echo esc_attr($price_current_min); ?>" data-price-current-max="<?php echo esc_attr($price_current_max); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +36,25 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if ($price_filter_enabled): ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range">
+              <div class="np-price-range__header">
+                <span class="np-price-value np-price-value--min"><?php echo esc_html($price_min_label); ?></span>
+                <button type="button" class="np-price-reset"><?php esc_html_e('Restablecer','norpumps'); ?></button>
+                <span class="np-price-value np-price-value--max"><?php echo esc_html($price_max_label); ?></span>
+              </div>
+              <div class="np-price-range__sliders">
+                <div class="np-price-progress"></div>
+                <input type="range" class="np-price-input" data-handle="min" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="1" value="<?php echo esc_attr($price_current_min); ?>">
+                <input type="range" class="np-price-input" data-handle="max" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="1" value="<?php echo esc_attr($price_current_max); ?>">
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/norpumps.php
+++ b/norpumps.php
@@ -60,6 +60,8 @@ class NorPumps_App {
         wp_localize_script('norpumps-store','NorpumpsStore',[
             'ajax_url'=>admin_url('admin-ajax.php'),
             'nonce'=>wp_create_nonce('norpumps_store'),
+            'currency_symbol'=>function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$',
+            'price_decimals'=>function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : 0,
         ]);
     }
     public function admin_assets($hook){


### PR DESCRIPTION
## Summary
- add admin controls and shortcode support for configuring a price filter range
- render a dual-handle price slider that coordinates with existing category filters and AJAX pagination
- style the new price filter UI and expose currency metadata for front-end formatting

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f04a3046b48330af6abd669e40cdda