### PR TITLE
Add price range filter to store module

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,6 +9,26 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.norpumps-filters .np-filter--price .np-filter__body{ padding:16px 18px; }
+.np-price-filter{ --np-price-accent:#083640; display:flex; flex-direction:column; gap:16px; }
+.np-price-filter__values{ display:flex; justify-content:space-between; align-items:flex-end; gap:12px; }
+.np-price-filter__value span{ display:block; font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:#6a7a83; margin-bottom:4px; }
+.np-price-filter__value strong{ display:block; font-size:18px; font-weight:700; color:var(--np-price-accent); }
+.np-price-filter__slider{ position:relative; height:42px; display:flex; align-items:center; }
+.np-price-filter__track{ position:absolute; left:0; right:0; height:6px; background:#dbe4e8; border-radius:999px; top:50%; transform:translateY(-50%); }
+.np-price-filter__progress{ position:absolute; height:6px; background:var(--np-price-accent); border-radius:999px; top:50%; transform:translateY(-50%); }
+.np-price-filter__range{ -webkit-appearance:none; appearance:none; position:absolute; width:100%; height:42px; background:transparent; pointer-events:none; margin:0; z-index:2; }
+.np-price-filter__range::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:20px; height:20px; border-radius:50%; background:var(--np-price-accent); border:3px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.25); pointer-events:auto; cursor:pointer; transition:transform .15s ease; }
+.np-price-filter__range::-moz-range-thumb{ width:20px; height:20px; border:none; border-radius:50%; background:var(--np-price-accent); box-shadow:0 4px 12px rgba(8,54,64,0.25); pointer-events:auto; cursor:pointer; }
+.np-price-filter__range::-webkit-slider-thumb:hover{ transform:scale(1.05); }
+.np-price-filter__range:focus-visible::-webkit-slider-thumb{ outline:3px solid rgba(8,54,64,0.35); outline-offset:2px; }
+.np-price-filter__range:focus-visible::-moz-range-thumb{ outline:3px solid rgba(8,54,64,0.35); outline-offset:2px; }
+.np-price-filter__range::-webkit-slider-runnable-track{ height:6px; background:transparent; }
+.np-price-filter__range::-moz-range-track{ height:6px; background:transparent; }
+.np-price-filter__footer{ display:flex; justify-content:flex-end; }
+.np-price-filter__reset{ background:none; border:none; color:var(--np-price-accent); font-weight:600; cursor:pointer; padding:4px 0; font-size:13px; text-decoration:underline; text-decoration-color:rgba(8,54,64,0.35); text-decoration-thickness:2px; }
+.np-price-filter__reset:hover{ text-decoration-color:var(--np-price-accent); }
+.np-price-filter__reset:focus-visible{ outline:2px solid rgba(8,54,64,0.35); outline-offset:2px; border-radius:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -6,8 +6,13 @@ jQuery(function($){
     'popularity':'DESC'
   };
   const SCROLL_OFFSET = 120;
+  const PRICE_TOLERANCE = 0.0001;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
 
+  function approxEqual(a, b, tolerance){
+    const limit = tolerance || PRICE_TOLERANCE;
+    return Math.abs(a - b) <= limit;
+  }
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
     return isFiniteNumber(val) && val > 0 ? val : 12;
@@ -38,6 +43,24 @@ jQuery(function($){
     setCurrentPage($root, fallback);
     return fallback;
   }
+  function getPriceDefaults($root){
+    const min = parseFloat($root.data('priceMin'));
+    const max = parseFloat($root.data('priceMax'));
+    const step = parseFloat($root.data('priceStep'));
+    return {
+      min: isFiniteNumber(min) ? min : 0,
+      max: isFiniteNumber(max) ? max : 0,
+      step: isFiniteNumber(step) && step > 0 ? step : 1
+    };
+  }
+  function getPriceSelection($root){
+    const $filter = $root.find('.np-price-filter');
+    if (!$filter.length) return null;
+    const min = parseFloat($filter.data('selectedMin'));
+    const max = parseFloat($filter.data('selectedMax'));
+    if (!isFiniteNumber(min) || !isFiniteNumber(max)) return null;
+    return { min, max };
+  }
   function buildQuery($root){
     const data = { action:'norpumps_store_query', nonce:NorpumpsStore.nonce };
     data.per_page = getPerPage($root);
@@ -56,17 +79,28 @@ jQuery(function($){
         data['cat_'+group] = vals.join(',');
       }
     });
+    const priceSelection = getPriceSelection($root);
+    const priceDefaults = getPriceDefaults($root);
+    if (priceSelection){
+      const minChanged = priceDefaults && isFiniteNumber(priceDefaults.min) ? priceSelection.min > priceDefaults.min : isFiniteNumber(priceSelection.min);
+      const maxChanged = priceDefaults && isFiniteNumber(priceDefaults.max) ? priceSelection.max < priceDefaults.max : isFiniteNumber(priceSelection.max);
+      if (minChanged){ data.price_min = priceSelection.min; }
+      if (maxChanged){ data.price_max = priceSelection.max; }
+    }
     return data;
   }
   function toQuery($root, obj){
     const params = new URLSearchParams();
     const defaultPer = getDefaultPerPage($root);
     const defaultPage = getDefaultPage($root);
+    const priceDefaults = getPriceDefaults($root);
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
+      if (key === 'price_min' && priceDefaults && isFiniteNumber(priceDefaults.min) && parseFloat(obj[key]) <= priceDefaults.min) return;
+      if (key === 'price_max' && priceDefaults && isFiniteNumber(priceDefaults.max) && parseFloat(obj[key]) >= priceDefaults.max) return;
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -114,6 +148,144 @@ jQuery(function($){
       load($root, 1, {scroll:true});
     });
   }
+  function initPriceFilter($root){
+    const $filter = $root.find('.np-price-filter');
+    if (!$filter.length) return;
+    const defaults = getPriceDefaults($root);
+    const rangeMinRaw = parseFloat($filter.data('rangeMin'));
+    const rangeMaxRaw = parseFloat($filter.data('rangeMax'));
+    const baseMin = isFiniteNumber(rangeMinRaw) ? rangeMinRaw : defaults.min;
+    const baseMax = isFiniteNumber(rangeMaxRaw) ? rangeMaxRaw : defaults.max;
+    const sliderStepRaw = parseFloat($filter.data('step'));
+    const sliderStep = isFiniteNumber(sliderStepRaw) && sliderStepRaw > 0 ? sliderStepRaw : defaults.step;
+    const formatter = (typeof Intl !== 'undefined' && Intl.NumberFormat) ? new Intl.NumberFormat(undefined, { maximumFractionDigits:0 }) : null;
+    const currencySymbol = $filter.data('currencySymbol') || '';
+    const currencyPosition = $filter.data('currencyPosition') || 'left';
+    const $progress = $filter.find('.np-price-filter__progress');
+    const $minInput = $filter.find('.np-price-filter__range--min');
+    const $maxInput = $filter.find('.np-price-filter__range--max');
+    const $minLabel = $filter.find('.js-np-price-min');
+    const $maxLabel = $filter.find('.js-np-price-max');
+    const $reset = $filter.find('.np-price-filter__reset');
+    if ($minInput.length){
+      $minInput.attr({ min: baseMin, max: baseMax, step: sliderStep });
+    }
+    if ($maxInput.length){
+      $maxInput.attr({ min: baseMin, max: baseMax, step: sliderStep });
+    }
+    function formatPrice(value){
+      const numberFormatted = formatter ? formatter.format(value) : String(value);
+      switch (currencyPosition){
+        case 'right':
+          return numberFormatted + currencySymbol;
+        case 'left_space':
+          return currencySymbol + ' ' + numberFormatted;
+        case 'right_space':
+          return numberFormatted + ' ' + currencySymbol;
+        case 'left':
+        default:
+          return currencySymbol + numberFormatted;
+      }
+    }
+    function alignToStep(value){
+      if (!isFiniteNumber(value)) return value;
+      if (!isFiniteNumber(sliderStep) || sliderStep <= 0) return value;
+      return baseMin + Math.round((value - baseMin) / sliderStep) * sliderStep;
+    }
+    function sanitizeRange(minValue, maxValue){
+      let nextMin = isFiniteNumber(minValue) ? minValue : baseMin;
+      let nextMax = isFiniteNumber(maxValue) ? maxValue : baseMax;
+      nextMin = alignToStep(nextMin);
+      nextMax = alignToStep(nextMax);
+      nextMin = Math.max(baseMin, Math.min(nextMin, baseMax));
+      nextMax = Math.max(baseMin, Math.min(nextMax, baseMax));
+      if (nextMin > nextMax){
+        const swap = nextMin;
+        nextMin = Math.max(baseMin, Math.min(nextMax, baseMax));
+        nextMax = Math.max(nextMin, Math.min(baseMax, swap));
+      }
+      if (nextMax - nextMin < sliderStep){
+        if (nextMin + sliderStep <= baseMax){
+          nextMax = nextMin + sliderStep;
+        } else {
+          nextMin = Math.max(baseMin, baseMax - sliderStep);
+          nextMax = Math.max(nextMin, Math.min(baseMax, nextMin + sliderStep));
+        }
+      }
+      if (!isFiniteNumber(nextMin)) nextMin = baseMin;
+      if (!isFiniteNumber(nextMax)) nextMax = baseMax;
+      return { min: nextMin, max: nextMax };
+    }
+    function updateProgress(minValue, maxValue){
+      if (!$progress.length) return;
+      const range = baseMax - baseMin;
+      if (!isFiniteNumber(range) || range <= 0){
+        $progress.css({ left:'0%', width:'100%' });
+        return;
+      }
+      const left = ((minValue - baseMin) / range) * 100;
+      const right = ((maxValue - baseMin) / range) * 100;
+      $progress.css({ left: left + '%', width: Math.max(right - left, 0) + '%' });
+    }
+    function setSelection(minValue, maxValue, options){
+      const sanitized = sanitizeRange(minValue, maxValue);
+      $filter.data('selectedMin', sanitized.min);
+      $filter.data('selectedMax', sanitized.max);
+      $filter.attr('data-selected-min', sanitized.min);
+      $filter.attr('data-selected-max', sanitized.max);
+      if ($minInput.length){ $minInput.val(sanitized.min); }
+      if ($maxInput.length){ $maxInput.val(sanitized.max); }
+      if ($minLabel.length){ $minLabel.text(formatPrice(sanitized.min)); }
+      if ($maxLabel.length){ $maxLabel.text(formatPrice(sanitized.max)); }
+      updateProgress(sanitized.min, sanitized.max);
+      if (options && options.commit){
+        $filter.data('committedMin', sanitized.min);
+        $filter.data('committedMax', sanitized.max);
+      }
+      return sanitized;
+    }
+    function triggerLoad(){
+      const selection = getPriceSelection($root);
+      if (!selection) return;
+      const committedMin = parseFloat($filter.data('committedMin'));
+      const committedMax = parseFloat($filter.data('committedMax'));
+      const tolerance = Math.max(sliderStep / 10, PRICE_TOLERANCE);
+      if (isFiniteNumber(committedMin) && isFiniteNumber(committedMax) && approxEqual(selection.min, committedMin, tolerance) && approxEqual(selection.max, committedMax, tolerance)){
+        return;
+      }
+      $filter.data('committedMin', selection.min);
+      $filter.data('committedMax', selection.max);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    }
+    const initialMin = parseFloat($filter.data('selectedMin'));
+    const initialMax = parseFloat($filter.data('selectedMax'));
+    const initial = setSelection(initialMin, initialMax, {commit:true});
+    if (!isFiniteNumber(parseFloat($filter.data('committedMin')))){
+      $filter.data('committedMin', initial.min);
+    }
+    if (!isFiniteNumber(parseFloat($filter.data('committedMax')))){
+      $filter.data('committedMax', initial.max);
+    }
+    if ($minInput.length){
+      $minInput.on('input', function(){ setSelection(parseFloat(this.value), parseFloat($maxInput.val())); });
+      $minInput.on('change', function(){ setSelection(parseFloat(this.value), parseFloat($maxInput.val())); triggerLoad(); });
+    }
+    if ($maxInput.length){
+      $maxInput.on('input', function(){ setSelection(parseFloat($minInput.val()), parseFloat(this.value)); });
+      $maxInput.on('change', function(){ setSelection(parseFloat($minInput.val()), parseFloat(this.value)); triggerLoad(); });
+    }
+    if ($reset.length){
+      $reset.on('click', function(e){
+        e.preventDefault();
+        const before = getPriceSelection($root);
+        const after = setSelection(baseMin, baseMax);
+        if (!before || !approxEqual(before.min, after.min, sliderStep) || !approxEqual(before.max, after.max, sliderStep)){
+          triggerLoad();
+        }
+      });
+    }
+  }
 
   $('.norpumps-store').each(function(){
     const $root = $(this);
@@ -157,6 +329,29 @@ jQuery(function($){
     if (isFiniteNumber(queryPer) && queryPer > 0){ setPerPage($root, queryPer); }
     const queryPage = parseInt(url.searchParams.get('page'), 10);
     if (isFiniteNumber(queryPage) && queryPage > 0){ setCurrentPage($root, queryPage); }
+
+    const $priceFilter = $root.find('.np-price-filter');
+    if ($priceFilter.length){
+      const rangeMinRaw = parseFloat($priceFilter.data('rangeMin'));
+      const rangeMaxRaw = parseFloat($priceFilter.data('rangeMax'));
+      const defaults = getPriceDefaults($root);
+      const baseMin = isFiniteNumber(rangeMinRaw) ? rangeMinRaw : defaults.min;
+      const baseMax = isFiniteNumber(rangeMaxRaw) ? rangeMaxRaw : defaults.max;
+      const queryMin = parseFloat(url.searchParams.get('price_min'));
+      const queryMax = parseFloat(url.searchParams.get('price_max'));
+      if (isFiniteNumber(queryMin)){
+        const clampedMin = Math.max(baseMin, Math.min(queryMin, baseMax));
+        $priceFilter.attr('data-selected-min', clampedMin);
+        $priceFilter.data('selectedMin', clampedMin);
+      }
+      if (isFiniteNumber(queryMax)){
+        const clampedMax = Math.max(baseMin, Math.min(queryMax, baseMax));
+        $priceFilter.attr('data-selected-max', clampedMax);
+        $priceFilter.data('selectedMax', clampedMax);
+      }
+    }
+
+    initPriceFilter($root);
 
     load($root, getCurrentPage($root), {scroll:false});
   });

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,36 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_min_default = isset($price_min_default) ? intval($price_min_default) : 0;
+$price_max_default = isset($price_max_default) ? intval($price_max_default) : 0;
+$price_step = isset($price_step) ? intval($price_step) : 1;
+$price_selected_min = isset($price_selected_min) ? intval($price_selected_min) : $price_min_default;
+$price_selected_max = isset($price_selected_max) ? intval($price_selected_max) : $price_max_default;
+$price_step = max(1, $price_step);
+if ($price_selected_min > $price_selected_max){
+  $price_selected_min = $price_min_default;
+  $price_selected_max = $price_max_default;
+}
+$currency_symbol = function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$';
+$currency_position = function_exists('get_option') ? get_option('woocommerce_currency_pos','left') : 'left';
+$format_price = function($value) use ($currency_symbol, $currency_position){
+  $formatted = number_format_i18n($value, 0);
+  switch ($currency_position) {
+    case 'right':
+      return $formatted.$currency_symbol;
+    case 'left_space':
+      return $currency_symbol.' '.$formatted;
+    case 'right_space':
+      return $formatted.' '.$currency_symbol;
+    case 'left':
+    default:
+      return $currency_symbol.$formatted;
+  }
+};
+$price_selected_min_label = $format_price($price_selected_min);
+$price_selected_max_label = $format_price($price_selected_max);
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-min="<?php echo esc_attr($price_min_default); ?>" data-price-max="<?php echo esc_attr($price_max_default); ?>" data-price-step="<?php echo esc_attr($price_step); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +55,34 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (in_array('price',$filters_arr)): ?>
+        <div class="np-filter np-filter--price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-filter" data-range-min="<?php echo esc_attr($price_min_default); ?>" data-range-max="<?php echo esc_attr($price_max_default); ?>" data-selected-min="<?php echo esc_attr($price_selected_min); ?>" data-selected-max="<?php echo esc_attr($price_selected_max); ?>" data-step="<?php echo esc_attr($price_step); ?>" data-currency-symbol="<?php echo esc_attr($currency_symbol); ?>" data-currency-position="<?php echo esc_attr($currency_position); ?>">
+              <div class="np-price-filter__values">
+                <div class="np-price-filter__value">
+                  <span><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                  <strong class="js-np-price-min"><?php echo esc_html($price_selected_min_label); ?></strong>
+                </div>
+                <div class="np-price-filter__value">
+                  <span><?php esc_html_e('Máximo','norpumps'); ?></span>
+                  <strong class="js-np-price-max"><?php echo esc_html($price_selected_max_label); ?></strong>
+                </div>
+              </div>
+              <div class="np-price-filter__slider" role="presentation">
+                <div class="np-price-filter__track"></div>
+                <div class="np-price-filter__progress"></div>
+                <input type="range" class="np-price-filter__range np-price-filter__range--min" min="<?php echo esc_attr($price_min_default); ?>" max="<?php echo esc_attr($price_max_default); ?>" value="<?php echo esc_attr($price_selected_min); ?>" step="<?php echo esc_attr($price_step); ?>" aria-label="<?php esc_attr_e('Precio mínimo','norpumps'); ?>">
+                <input type="range" class="np-price-filter__range np-price-filter__range--max" min="<?php echo esc_attr($price_min_default); ?>" max="<?php echo esc_attr($price_max_default); ?>" value="<?php echo esc_attr($price_selected_max); ?>" step="<?php echo esc_attr($price_step); ?>" aria-label="<?php esc_attr_e('Precio máximo','norpumps'); ?>">
+              </div>
+              <div class="np-price-filter__footer">
+                <button type="button" class="np-price-filter__reset"><?php esc_html_e('Restablecer','norpumps'); ?></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add configurable price range support to the store shortcode and WooCommerce query builder
- render a dual-handle price slider with reset control and updated styling
- update store frontend script to sync the price filter with AJAX queries, URL state, and other filters

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f04a3046b48330af6abd669e40cdda