### PR TITLE
Add price range filter to store shortcode

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -13,6 +13,37 @@
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
 .norpumps-filters .np-all{ display:block; margin:4px 0 10px; font-weight:600; }
+.np-filter--price .np-filter__body{ background:#f3fafb; border-color:rgba(8,54,64,0.18); box-shadow:inset 0 0 0 1px rgba(8,54,64,0.05); }
+.np-price-range{ display:flex; flex-direction:column; gap:18px; }
+.np-price-range__summary{ display:flex; justify-content:space-between; gap:16px; background:rgba(8,54,64,0.1); border-radius:14px; padding:14px 18px; color:#083640; font-weight:600; box-shadow:inset 0 0 0 1px rgba(8,54,64,0.05); }
+.np-price-range__summary-item{ flex:1; }
+.np-price-range__summary-item span{ display:block; font-size:11px; text-transform:uppercase; letter-spacing:.08em; margin-bottom:4px; opacity:.7; }
+.np-price-range__value{ font-size:16px; font-weight:700; line-height:1.35; }
+.np-price-range__slider{ position:relative; height:44px; display:flex; align-items:center; }
+.np-price-range__track{ position:absolute; left:0; right:0; top:50%; transform:translateY(-50%); height:10px; border-radius:999px; background:#d7dee2; overflow:hidden; box-shadow:inset 0 2px 6px rgba(8,54,64,0.15); }
+.np-price-range__track::before{ content:""; position:absolute; top:0; bottom:0; left:var(--np-range-start, 0%); width:calc(var(--np-range-end, 100%) - var(--np-range-start, 0%)); background:linear-gradient(90deg, rgba(8,54,64,0.95), rgba(8,54,64,0.7)); border-radius:inherit; }
+.np-price-range__control{ position:absolute; left:0; right:0; top:0; bottom:0; width:100%; margin:0; background:transparent; pointer-events:none; -webkit-appearance:none; appearance:none; }
+.np-price-range__control:focus{ outline:none; }
+.np-price-range__control::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#fff; border:3px solid var(--np-price-color,#083640); box-shadow:0 6px 14px rgba(8,54,64,0.28); transition:transform .2s ease, box-shadow .2s ease; }
+.np-price-range__control::-webkit-slider-thumb:hover{ transform:scale(1.05); box-shadow:0 8px 18px rgba(8,54,64,0.32); }
+.np-price-range__control::-moz-range-thumb{ pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#fff; border:3px solid var(--np-price-color,#083640); box-shadow:0 6px 14px rgba(8,54,64,0.28); transition:transform .2s ease, box-shadow .2s ease; }
+.np-price-range__control::-moz-range-thumb:hover{ transform:scale(1.05); box-shadow:0 8px 18px rgba(8,54,64,0.32); }
+.np-price-range__control::-ms-thumb{ pointer-events:auto; width:20px; height:20px; border-radius:50%; background:#fff; border:3px solid var(--np-price-color,#083640); box-shadow:0 6px 14px rgba(8,54,64,0.28); }
+.np-price-range__control::-webkit-slider-runnable-track{ background:transparent; }
+.np-price-range__control::-moz-range-track{ background:transparent; border:none; }
+.np-price-range__control::-ms-track{ background:transparent; border-color:transparent; color:transparent; }
+.np-price-range__fields{ display:flex; flex-wrap:wrap; gap:14px; align-items:flex-end; }
+.np-price-range__fields label{ display:flex; flex-direction:column; gap:6px; font-size:12px; font-weight:700; color:#083640; }
+.np-price-range__number{ padding:8px 12px; border:1px solid rgba(8,54,64,0.2); border-radius:10px; background:#fff; min-width:120px; font-weight:600; color:#083640; box-shadow:0 2px 6px rgba(8,54,64,0.08) inset; }
+.np-price-range__number:focus{ outline:none; border-color:var(--np-price-color,#083640); box-shadow:0 0 0 3px rgba(8,54,64,0.15); }
+.np-price-range__reset{ margin-left:auto; padding:10px 18px; border-radius:999px; border:none; background:var(--np-price-color,#083640); color:#fff; font-weight:700; letter-spacing:.04em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; }
+.np-price-range__reset:hover{ transform:translateY(-1px); box-shadow:0 10px 18px rgba(8,54,64,0.25); background:#0a4d57; }
+.np-price-range__reset:focus{ outline:none; box-shadow:0 0 0 3px rgba(8,54,64,0.25); }
+.np-price-range__reset:active{ transform:translateY(0); box-shadow:0 6px 12px rgba(8,54,64,0.22); }
+.np-price-range__fields label span{ text-transform:uppercase; letter-spacing:.06em; opacity:.7; }
+.np-price-range__fields label input::-webkit-outer-spin-button,
+.np-price-range__fields label input::-webkit-inner-spin-button{ -webkit-appearance:none; margin:0; }
+.np-price-range__fields label input[type=number]{ -moz-appearance:textfield; }
 .np-grid{ display:grid; gap:28px; }
 .np-grid[data-columns="2"]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 .np-grid[data-columns="3"]{ grid-template-columns: repeat(3,minmax(0,1fr)); }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -7,6 +7,114 @@ jQuery(function($){
   };
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };
+  function clamp(value, min, max){
+    let result = parseFloat(value);
+    if (!isFiniteNumber(result)){ result = isFiniteNumber(min) ? min : 0; }
+    if (isFiniteNumber(min)){ result = Math.max(result, min); }
+    if (isFiniteNumber(max)){ result = Math.min(result, max); }
+    return result;
+  }
+  function getPriceRange($root){
+    const $range = $root.find('.np-price-range');
+    return $range.length ? $range : null;
+  }
+  function getPriceOptions($range){
+    if (!$range || !$range.length) return null;
+    const cached = $range.data('priceOptions');
+    if (cached){ return cached; }
+    const min = parseFloat($range.data('defaultMin'));
+    const max = parseFloat($range.data('defaultMax'));
+    const decimalsRaw = parseInt($range.data('currencyDecimals'), 10);
+    const decimalSep = ($range.data('currencyDecimalSep') || '.').toString();
+    const thousandSep = ($range.data('currencyThousandSep') || ',').toString();
+    const symbolRaw = typeof $range.data('currencySymbol') === 'string' ? $range.data('currencySymbol') : '$';
+    const decodedSymbol = $('<textarea/>').html(symbolRaw).text() || '$';
+    const symbolHtml = $('<div/>').text(decodedSymbol).html();
+    const options = {
+      min: isFiniteNumber(min) ? min : 0,
+      max: isFiniteNumber(max) ? max : 0,
+      decimals: isFiniteNumber(decimalsRaw) ? decimalsRaw : 0,
+      decimalSep,
+      thousandSep,
+      symbol: decodedSymbol,
+      symbolHtml
+    };
+    $range.data('priceOptions', options);
+    return options;
+  }
+  function formatPriceDisplay(value, options){
+    if (!options){ return ''; }
+    const decimals = Math.max(0, options.decimals || 0);
+    const multiplier = Math.pow(10, decimals);
+    let numeric = parseFloat(value);
+    if (!isFiniteNumber(numeric)){ numeric = 0; }
+    numeric = Math.round(numeric * multiplier) / multiplier;
+    const fixed = numeric.toFixed(decimals);
+    const parts = fixed.split('.');
+    let intPart = parts[0];
+    const decPart = parts.length > 1 ? parts[1] : '';
+    intPart = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, options.thousandSep || ',');
+    const currencyHtml = '<span class="woocommerce-Price-currencySymbol">'+(options.symbolHtml || options.symbol || '$')+'</span>';
+    const decimalHtml = decimals > 0 ? (options.decimalSep || '.') + decPart : '';
+    return '<span class="woocommerce-Price-amount amount"><bdi>'+currencyHtml+intPart+decimalHtml+'</bdi></span>';
+  }
+  function updatePriceRangeUI($range, minVal, maxVal, providedOptions){
+    if (!$range || !$range.length) return;
+    const options = providedOptions || getPriceOptions($range);
+    if (!options) return;
+    const decimals = Math.max(0, options.decimals || 0);
+    const multiplier = Math.pow(10, decimals);
+    const safeMin = Math.round(minVal * multiplier) / multiplier;
+    const safeMax = Math.round(maxVal * multiplier) / multiplier;
+    const $minDisplay = $range.find('[data-role="min-display"]');
+    const $maxDisplay = $range.find('[data-role="max-display"]');
+    if ($minDisplay.length){ $minDisplay.html(formatPriceDisplay(safeMin, options)); }
+    if ($maxDisplay.length){ $maxDisplay.html(formatPriceDisplay(safeMax, options)); }
+    const denom = options.max - options.min;
+    let startPct = denom > 0 ? ((safeMin - options.min) / denom) * 100 : 0;
+    let endPct = denom > 0 ? ((safeMax - options.min) / denom) * 100 : 100;
+    startPct = Math.max(0, Math.min(100, startPct));
+    endPct = Math.max(0, Math.min(100, endPct));
+    $range.find('.np-price-range__track').css({'--np-range-start': startPct + '%', '--np-range-end': endPct + '%'});
+    $range.data('currentMin', safeMin);
+    $range.data('currentMax', safeMax);
+  }
+  function syncPriceRange($range, newMin, newMax){
+    if (!$range || !$range.length) return null;
+    const options = getPriceOptions($range);
+    if (!options) return null;
+    const decimals = Math.max(0, options.decimals || 0);
+    const multiplier = Math.pow(10, decimals);
+    const currentMin = parseFloat($range.find('.np-price-range__control--min').val());
+    const currentMax = parseFloat($range.find('.np-price-range__control--max').val());
+    let minVal = typeof newMin !== 'undefined' ? newMin : currentMin;
+    let maxVal = typeof newMax !== 'undefined' ? newMax : currentMax;
+    if (!isFiniteNumber(minVal)){ minVal = options.min; }
+    if (!isFiniteNumber(maxVal)){ maxVal = options.max; }
+    minVal = clamp(minVal, options.min, options.max);
+    maxVal = clamp(maxVal, options.min, options.max);
+    if (minVal > maxVal){
+      if (typeof newMin !== 'undefined' && typeof newMax === 'undefined'){
+        maxVal = minVal;
+      } else if (typeof newMax !== 'undefined' && typeof newMin === 'undefined'){
+        minVal = maxVal;
+      } else {
+        const middle = (minVal + maxVal) / 2;
+        minVal = middle;
+        maxVal = middle;
+      }
+    }
+    minVal = Math.round(minVal * multiplier) / multiplier;
+    maxVal = Math.round(maxVal * multiplier) / multiplier;
+    const minString = decimals > 0 ? minVal.toFixed(decimals) : String(Math.round(minVal));
+    const maxString = decimals > 0 ? maxVal.toFixed(decimals) : String(Math.round(maxVal));
+    $range.find('.np-price-range__control--min').val(minString);
+    $range.find('.np-price-range__control--max').val(maxString);
+    $range.find('.np-price-range__number--min').val(minString);
+    $range.find('.np-price-range__number--max').val(maxString);
+    updatePriceRangeUI($range, minVal, maxVal, options);
+    return {min:minVal, max:maxVal, minString, maxString, options};
+  }
 
   function getDefaultPerPage($root){
     const val = parseInt($root.data('defaultPerPage'), 10);
@@ -48,6 +156,14 @@ jQuery(function($){
     if (orderDir){ data.order = orderDir; }
     const search = $root.find('.np-search').val();
     if (search){ data.s = search; }
+    const $priceRange = getPriceRange($root);
+    if ($priceRange){
+      const priceState = syncPriceRange($priceRange);
+      if (priceState){
+        data.min_price = priceState.minString;
+        data.max_price = priceState.maxString;
+      }
+    }
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
       const group = $(this).data('group');
       const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
@@ -62,11 +178,24 @@ jQuery(function($){
     const params = new URLSearchParams();
     const defaultPer = getDefaultPerPage($root);
     const defaultPage = getDefaultPage($root);
+    let priceDefaults = null;
+    const $priceRange = getPriceRange($root);
+    if ($priceRange){
+      const options = getPriceOptions($priceRange);
+      if (options){
+        const decimals = Math.max(0, options.decimals || 0);
+        const minDefault = decimals > 0 ? options.min.toFixed(decimals) : String(Math.round(options.min));
+        const maxDefault = decimals > 0 ? options.max.toFixed(decimals) : String(Math.round(options.max));
+        priceDefaults = { min:minDefault, max:maxDefault };
+      }
+    }
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
+      if (priceDefaults && key === 'min_price' && String(obj[key]) === priceDefaults.min) return;
+      if (priceDefaults && key === 'max_price' && String(obj[key]) === priceDefaults.max) return;
       params.set(key, obj[key]);
     });
     return params.toString();
@@ -114,6 +243,50 @@ jQuery(function($){
       load($root, 1, {scroll:true});
     });
   }
+  function bindPriceRange($root){
+    const $range = getPriceRange($root);
+    if (!$range) return;
+    syncPriceRange($range);
+    $root.on('input', '.np-price-range__control--min', function(){
+      const $localRange = $(this).closest('.np-price-range');
+      syncPriceRange($localRange, parseFloat(this.value), undefined);
+    });
+    $root.on('input', '.np-price-range__control--max', function(){
+      const $localRange = $(this).closest('.np-price-range');
+      syncPriceRange($localRange, undefined, parseFloat(this.value));
+    });
+    $root.on('change', '.np-price-range__control', function(){
+      const $localRange = $(this).closest('.np-price-range');
+      syncPriceRange($localRange);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+    $root.on('input', '.np-price-range__number--min', function(){
+      if (this.value === '') return;
+      const $localRange = $(this).closest('.np-price-range');
+      syncPriceRange($localRange, parseFloat(this.value), undefined);
+    });
+    $root.on('input', '.np-price-range__number--max', function(){
+      if (this.value === '') return;
+      const $localRange = $(this).closest('.np-price-range');
+      syncPriceRange($localRange, undefined, parseFloat(this.value));
+    });
+    $root.on('change', '.np-price-range__number', function(){
+      const $localRange = $(this).closest('.np-price-range');
+      syncPriceRange($localRange);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+    $root.on('click', '.np-price-range__reset', function(e){
+      e.preventDefault();
+      const $localRange = $(this).closest('.np-price-range');
+      const options = getPriceOptions($localRange);
+      if (!options) return;
+      syncPriceRange($localRange, options.min, options.max);
+      resetToFirstPage($root);
+      load($root, 1, {scroll:true});
+    });
+  }
 
   $('.norpumps-store').each(function(){
     const $root = $(this);
@@ -131,6 +304,7 @@ jQuery(function($){
     });
 
     bindAllToggle($root);
+    bindPriceRange($root);
 
     const url = new URL(window.location.href);
     $root.find('.np-checklist[data-tax="product_cat"]').each(function(){
@@ -157,6 +331,19 @@ jQuery(function($){
     if (isFiniteNumber(queryPer) && queryPer > 0){ setPerPage($root, queryPer); }
     const queryPage = parseInt(url.searchParams.get('page'), 10);
     if (isFiniteNumber(queryPage) && queryPage > 0){ setCurrentPage($root, queryPage); }
+    const $priceRange = getPriceRange($root);
+    if ($priceRange){
+      const options = getPriceOptions($priceRange);
+      if (options){
+        let initMin = options.min;
+        let initMax = options.max;
+        const queryMin = parseFloat(url.searchParams.get('min_price'));
+        const queryMax = parseFloat(url.searchParams.get('max_price'));
+        if (isFiniteNumber(queryMin)){ initMin = queryMin; }
+        if (isFiniteNumber(queryMax)){ initMax = queryMax; }
+        syncPriceRange($priceRange, initMin, initMax);
+      }
+    }
 
     load($root, getCurrentPage($root), {scroll:false});
   });

--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -104,9 +104,21 @@ class NorPumps_Modules_Store {
             'groups'=>'', // "Label:slugPadre|Label2:slugPadre2"
             'show_all'=>'yes',
             'per_page'=>12,'order'=>'menu_order title','page'=>1,
+            'price_min'=>0,
+            'price_max'=>0,
         ], $atts, 'norpumps_store');
         $columns = max(2, min(6, intval($atts['columns'])));
         $per_page = max(1, min(60, intval($atts['per_page'])));
+        $price_min = max(0.0, floatval($atts['price_min']));
+        $price_max = max(0.0, floatval($atts['price_max']));
+        if ($price_max <= 0){
+            $price_max = 0;
+        }
+        if ($price_max && $price_min > $price_max){
+            $tmp = $price_min;
+            $price_min = $price_max;
+            $price_max = $tmp;
+        }
         $groups = [];
         foreach (array_filter(array_map('trim', explode('|',$atts['groups']))) as $chunk){
             $parts = array_map('trim', explode(':',$chunk,2));
@@ -172,6 +184,14 @@ class NorPumps_Modules_Store {
         }
         $search = sanitize_text_field(norpumps_array_get($_REQUEST,'s',''));
         if ($search !== ''){ $args['s'] = $search; }
+        $min_price = norpumps_array_get($_REQUEST,'min_price','');
+        $max_price = norpumps_array_get($_REQUEST,'max_price','');
+        if ($min_price !== ''){
+            $args['min_price'] = max(0, floatval($min_price));
+        }
+        if ($max_price !== ''){
+            $args['max_price'] = max(0, floatval($max_price));
+        }
         if (count($tax_query)>1) $args['tax_query']=$tax_query;
         return $args;
     }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,6 +7,47 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$has_price_filter = in_array('price', $filters_arr, true);
+$configured_price_min = isset($price_min) ? floatval($price_min) : 0;
+$configured_price_max = isset($price_max) && floatval($price_max) > 0 ? floatval($price_max) : 10000;
+if ($configured_price_max <= $configured_price_min){
+  $configured_price_max = $configured_price_min + 1;
+}
+$request_min_price = isset($_GET['min_price']) ? floatval($_GET['min_price']) : $configured_price_min;
+$request_max_price = isset($_GET['max_price']) ? floatval($_GET['max_price']) : $configured_price_max;
+$current_min_price = max($configured_price_min, min($request_min_price, $configured_price_max));
+$current_max_price = max($configured_price_min, min($request_max_price, $configured_price_max));
+if ($current_min_price > $current_max_price){
+  $swap = $current_min_price;
+  $current_min_price = $current_max_price;
+  $current_max_price = $swap;
+}
+$price_color = '#083640';
+$currency_symbol = function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$';
+$price_decimals = function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : 0;
+$price_decimal_separator = function_exists('wc_get_price_decimal_separator') ? wc_get_price_decimal_separator() : '.';
+$price_thousand_separator = function_exists('wc_get_price_thousand_separator') ? wc_get_price_thousand_separator() : ',';
+$range_denominator = $configured_price_max - $configured_price_min;
+if ($range_denominator <= 0){
+  $range_denominator = 1;
+}
+$range_start_percent = max(0, min(100, ($current_min_price - $configured_price_min) / $range_denominator * 100));
+$range_end_percent = max(0, min(100, ($current_max_price - $configured_price_min) / $range_denominator * 100));
+$price_step = $price_decimals > 0 ? number_format(1 / pow(10, $price_decimals), $price_decimals, '.', '') : 1;
+$formatted_configured_min = number_format($configured_price_min, $price_decimals, '.', '');
+$formatted_configured_max = number_format($configured_price_max, $price_decimals, '.', '');
+$formatted_current_min = number_format($current_min_price, $price_decimals, '.', '');
+$formatted_current_max = number_format($current_max_price, $price_decimals, '.', '');
+$format_price_display = function($value) use ($currency_symbol, $price_decimals, $price_decimal_separator, $price_thousand_separator){
+  if (function_exists('wc_price')){
+    return wc_price($value);
+  }
+  $formatted = esc_html(number_format($value, $price_decimals, $price_decimal_separator ?: '.', $price_thousand_separator ?: ','));
+  $symbol = esc_html($currency_symbol);
+  return '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">'.$symbol.'</span>'.$formatted.'</bdi></span>';
+};
+$initial_min_display = $format_price_display($current_min_price);
+$initial_max_display = $format_price_display($current_max_price);
 ?>
 <div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
   <div class="norpumps-store__header">
@@ -27,6 +68,41 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if ($has_price_filter): ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-default-min="<?php echo esc_attr($formatted_configured_min); ?>" data-default-max="<?php echo esc_attr($formatted_configured_max); ?>" data-color="<?php echo esc_attr($price_color); ?>" data-currency-symbol="<?php echo esc_attr($currency_symbol); ?>" data-currency-decimals="<?php echo esc_attr($price_decimals); ?>" data-currency-decimal-sep="<?php echo esc_attr($price_decimal_separator); ?>" data-currency-thousand-sep="<?php echo esc_attr($price_thousand_separator); ?>" style="--np-price-color: <?php echo esc_attr($price_color); ?>;">
+              <div class="np-price-range__summary">
+                <div class="np-price-range__summary-item">
+                  <span><?php esc_html_e('Desde','norpumps'); ?></span>
+                  <strong class="np-price-range__value np-price-range__value--min" data-role="min-display"><?php echo wp_kses_post($initial_min_display); ?></strong>
+                </div>
+                <div class="np-price-range__summary-item">
+                  <span><?php esc_html_e('Hasta','norpumps'); ?></span>
+                  <strong class="np-price-range__value np-price-range__value--max" data-role="max-display"><?php echo wp_kses_post($initial_max_display); ?></strong>
+                </div>
+              </div>
+              <div class="np-price-range__slider">
+                <div class="np-price-range__track" style="--np-range-start:<?php echo esc_attr($range_start_percent); ?>%; --np-range-end:<?php echo esc_attr($range_end_percent); ?>%;"></div>
+                <input type="range" class="np-price-range__control np-price-range__control--min" min="<?php echo esc_attr($formatted_configured_min); ?>" max="<?php echo esc_attr($formatted_configured_max); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($formatted_current_min); ?>" aria-label="<?php esc_attr_e('Precio mínimo','norpumps'); ?>">
+                <input type="range" class="np-price-range__control np-price-range__control--max" min="<?php echo esc_attr($formatted_configured_min); ?>" max="<?php echo esc_attr($formatted_configured_max); ?>" step="<?php echo esc_attr($price_step); ?>" value="<?php echo esc_attr($formatted_current_max); ?>" aria-label="<?php esc_attr_e('Precio máximo','norpumps'); ?>">
+              </div>
+              <div class="np-price-range__fields">
+                <label>
+                  <span><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                  <input type="number" class="np-price-range__number np-price-range__number--min" value="<?php echo esc_attr($formatted_current_min); ?>" min="<?php echo esc_attr($formatted_configured_min); ?>" max="<?php echo esc_attr($formatted_configured_max); ?>" step="<?php echo esc_attr($price_step); ?>">
+                </label>
+                <label>
+                  <span><?php esc_html_e('Máximo','norpumps'); ?></span>
+                  <input type="number" class="np-price-range__number np-price-range__number--max" value="<?php echo esc_attr($formatted_current_max); ?>" min="<?php echo esc_attr($formatted_configured_min); ?>" max="<?php echo esc_attr($formatted_configured_max); ?>" step="<?php echo esc_attr($price_step); ?>">
+                </label>
+                <button type="button" class="np-price-range__reset"><?php esc_html_e('Restablecer','norpumps'); ?></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add price range shortcode options and feed them into the store template
- implement a dual-handle price slider UI with refreshed styling and JS behaviour
- hook WooCommerce queries and URL/state management so price filters work alongside category filters

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f04a3046b48330af6abd669e40cdda