### PR TITLE
Improve price filter styling and live updates

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -1,5 +1,5 @@
 /* v1.2.1 — estilo similar al screenshot */
-.norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; }
+.norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; --np-price-accent:#083640; }
 .norpumps-store a { color:#0a66a1; text-decoration:none; }
 .norpumps-store .norpumps-store__header{ display:flex; justify-content:space-between; align-items:center; margin:10px 0 20px; }
 .norpumps-store .np-orderby select, .norpumps-store .np-search input{ padding:8px 10px; border:1px solid #d7dee2; border-radius:6px; background:#fff; }
@@ -9,6 +9,43 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.norpumps-filters .np-filter--price .np-filter__head{ background:var(--np-price-accent); }
+.norpumps-filters .np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:14px; }
+.np-price-range{ display:flex; flex-direction:column; gap:14px; }
+.np-price-range__header{ display:flex; align-items:center; justify-content:space-between; gap:12px; font-weight:600; color:var(--np-price-accent); }
+.np-price-value{ font-size:14px; }
+.np-price-reset{ background:transparent; border:1px solid var(--np-price-accent); color:var(--np-price-accent); border-radius:999px; padding:6px 14px; font-size:13px; font-weight:600; cursor:pointer; transition:all .2s ease; }
+.np-price-reset:hover{ background:var(--np-price-accent); color:#fff; }
+.np-price-range__sliders{ position:relative; height:38px; padding:0; }
+.np-price-range__sliders::before{ content:""; position:absolute; top:50%; left:0; right:0; transform:translateY(-50%); height:8px; border-radius:999px; background:linear-gradient(90deg,#d4e0e4 0%, #e9f1f3 100%); box-shadow:inset 0 0 0 1px rgba(8,54,64,0.15); }
+.np-price-progress{
+  position:absolute;
+  top:50%;
+  left:0;
+  transform:translateY(-50%);
+  height:8px;
+  border-radius:999px;
+  background:linear-gradient(90deg,#0d5158 0%, #083640 100%);
+  box-shadow:0 4px 10px rgba(8,54,64,0.25);
+  z-index:1;
+  width:0;
+  transition:left .12s linear, width .12s linear;
+}
+.np-price-input{ position:absolute; left:0; right:0; width:100%; height:38px; margin:0; padding:0; appearance:none; background:none; pointer-events:none; z-index:2; }
+.np-price-input::-webkit-slider-thumb{ appearance:none; pointer-events:auto; width:18px; height:18px; border-radius:50%; background:var(--np-price-accent); border:2px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); cursor:pointer; }
+.np-price-input::-webkit-slider-runnable-track{ height:6px; background:transparent; }
+.np-price-input::-moz-range-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:var(--np-price-accent); border:2px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); cursor:pointer; }
+.np-price-input::-moz-range-track{ height:6px; background:transparent; }
+.np-price-input::-ms-thumb{ pointer-events:auto; width:18px; height:18px; border-radius:50%; background:var(--np-price-accent); border:2px solid #fff; box-shadow:0 4px 12px rgba(8,54,64,0.35); cursor:pointer; }
+.np-price-input::-ms-track{ height:6px; background:transparent; border-color:transparent; color:transparent; }
+.np-price-input::-ms-fill-lower, .np-price-input::-ms-fill-upper{ background:transparent; }
+.np-price-input:focus{ outline:none; }
+.np-price-input:focus::-webkit-slider-thumb,
+.np-price-input:focus-visible::-webkit-slider-thumb,
+.np-price-input:focus::-moz-range-thumb,
+.np-price-input:focus-visible::-moz-range-thumb{
+  box-shadow:0 0 0 4px rgba(8,54,64,0.25);
+}
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
@@ -44,6 +81,7 @@
 .norpumps-admin .np-chip{ display:inline-flex; align-items:center; gap:6px; background:#eef7f8; padding:6px 10px; border-radius:999px; margin-right:8px; }
 .norpumps-admin .np-group{ display:flex; gap:10px; align-items:center; margin:8px 0; }
 .norpumps-admin .np-group input{ padding:6px 8px; }
+.norpumps-admin .np-row--price input{ max-width:160px; }
 .norpumps-admin .np-autocomplete{ position:relative; background:#fff; border:1px solid #ccd; padding:6px; border-radius:8px; margin-top:6px; max-width:520px; }
 .norpumps-admin .np-autocomplete .np-opt{ padding:6px 8px; cursor:pointer; }
 .norpumps-admin .np-autocomplete .np-opt:hover{ background:#f5f8fb; }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,17 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$price_filter_enabled = isset($price_filter_enabled) ? (bool)$price_filter_enabled : false;
+$price_min_attr = isset($price_min_attr) ? floatval($price_min_attr) : 0.0;
+$price_max_attr = isset($price_max_attr) ? floatval($price_max_attr) : 0.0;
+$price_current_min = isset($price_current_min) ? floatval($price_current_min) : $price_min_attr;
+$price_current_max = isset($price_current_max) ? floatval($price_current_max) : $price_max_attr;
+$currency_symbol = function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$';
+$price_decimals = function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : 0;
+$price_min_label = $currency_symbol . ' ' . number_format_i18n($price_current_min, $price_decimals);
+$price_max_label = $currency_symbol . ' ' . number_format_i18n($price_current_max, $price_decimals);
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-enabled="<?php echo esc_attr($price_filter_enabled ? '1' : '0'); ?>" data-price-min="<?php echo esc_attr($price_min_attr); ?>" data-price-max="<?php echo esc_attr($price_max_attr); ?>" data-price-current-min="<?php echo esc_attr($price_current_min); ?>" data-price-current-max="<?php echo esc_attr($price_current_max); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +36,25 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if ($price_filter_enabled): ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range">
+              <div class="np-price-range__header">
+                <span class="np-price-value np-price-value--min"><?php echo esc_html($price_min_label); ?></span>
+                <button type="button" class="np-price-reset"><?php esc_html_e('Restablecer','norpumps'); ?></button>
+                <span class="np-price-value np-price-value--max"><?php echo esc_html($price_max_label); ?></span>
+              </div>
+              <div class="np-price-range__sliders">
+                <div class="np-price-progress"></div>
+                <input type="range" class="np-price-input" data-handle="min" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="1" value="<?php echo esc_attr($price_current_min); ?>">
+                <input type="range" class="np-price-input" data-handle="max" min="<?php echo esc_attr($price_min_attr); ?>" max="<?php echo esc_attr($price_max_attr); ?>" step="1" value="<?php echo esc_attr($price_current_max); ?>">
+              </div>
+            </div>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');

--- a/norpumps.php
+++ b/norpumps.php
@@ -60,6 +60,8 @@ class NorPumps_App {
         wp_localize_script('norpumps-store','NorpumpsStore',[
             'ajax_url'=>admin_url('admin-ajax.php'),
             'nonce'=>wp_create_nonce('norpumps_store'),
+            'currency_symbol'=>function_exists('get_woocommerce_currency_symbol') ? get_woocommerce_currency_symbol() : '$',
+            'price_decimals'=>function_exists('wc_get_price_decimals') ? wc_get_price_decimals() : 0,
         ]);
     }
     public function admin_assets($hook){


### PR DESCRIPTION
## Summary
- restyle the price slider with a visible track, gradient progress bar, and focus feedback
- throttle price slider input so AJAX requests run in real time without duplicates and stay in sync with other filters
- enforce the selected price range server-side by adding numeric meta clauses to the WooCommerce query builder

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f04a3046b48330af6abd669e40cdda