### PR TITLE
Add price range filter to store module

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,6 +9,16 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:12px; }
+.np-price-range{ display:flex; flex-wrap:wrap; align-items:flex-end; gap:12px; }
+.np-price-field{ display:flex; flex-direction:column; gap:6px; min-width:120px; }
+.np-price-field label{ font-size:13px; font-weight:600; color:#0f5b62; letter-spacing:.02em; text-transform:uppercase; }
+.np-price-field input{ padding:8px 10px; border:1px solid #d7dee2; border-radius:8px; background:#f9fbfc; font-weight:600; color:#0f5b62; }
+.np-price-field input:focus{ outline:none; border-color:#0f5b62; box-shadow:0 0 0 3px rgba(15,91,98,0.15); background:#fff; }
+.np-price-divider{ font-weight:700; color:#0f5b62; font-size:20px; line-height:1; padding-bottom:8px; }
+.np-price-apply.button{ align-self:flex-start; background:linear-gradient(135deg,#1f7c85,#0f5b62); border:none; padding:8px 18px; border-radius:999px; box-shadow:0 6px 16px rgba(15,91,98,0.18); }
+.np-price-apply.button:hover{ filter:brightness(1.05); }
+.np-price-apply.button:focus{ outline:none; box-shadow:0 0 0 3px rgba(31,124,133,0.25); }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -6,9 +6,25 @@ $default_page_attr = isset($default_page) ? intval($default_page) : 1;
 $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
+$price_min_default = isset($default_price_min) ? floatval($default_price_min) : 0;
+$price_max_default = isset($default_price_max) ? floatval($default_price_max) : 0;
+$price_min_value = isset($requested_price_min) ? floatval($requested_price_min) : $price_min_default;
+$price_max_value = isset($requested_price_max) ? floatval($requested_price_max) : $price_max_default;
+if ($price_max_value < $price_min_value){
+  $tmp = $price_min_value;
+  $price_min_value = $price_max_value;
+  $price_max_value = $tmp;
+}
 if (!isset($filters_arr)) $filters_arr = [];
+$format_price_input = function($value){
+  $value = floatval($value);
+  $formatted = number_format($value, 2, '.', '');
+  $formatted = preg_replace('/\.0+$/', '', $formatted);
+  $formatted = preg_replace('/(\.[0-9]*[1-9])0+$/', '$1', $formatted);
+  return $formatted;
+};
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-default-price-min="<?php echo esc_attr($format_price_input($price_min_default)); ?>" data-default-price-max="<?php echo esc_attr($format_price_input($price_max_default)); ?>" data-price-min="<?php echo esc_attr($format_price_input($price_min_value)); ?>" data-price-max="<?php echo esc_attr($format_price_input($price_max_value)); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +43,25 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if (in_array('price',$filters_arr)): ?>
+        <div class="np-filter np-filter--price" data-filter="price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range">
+              <div class="np-price-field">
+                <label for="np-price-min"><?php esc_html_e('Mínimo','norpumps'); ?></label>
+                <input type="number" step="0.01" min="0" class="np-price-input np-price-min" id="np-price-min" value="<?php echo esc_attr($format_price_input($price_min_value)); ?>">
+              </div>
+              <span class="np-price-divider">—</span>
+              <div class="np-price-field">
+                <label for="np-price-max"><?php esc_html_e('Máximo','norpumps'); ?></label>
+                <input type="number" step="0.01" min="0" class="np-price-input np-price-max" id="np-price-max" value="<?php echo esc_attr($format_price_input($price_max_value)); ?>">
+              </div>
+            </div>
+            <button type="button" class="button button-primary np-price-apply"><?php esc_html_e('Aplicar','norpumps'); ?></button>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add a styled price range filter UI that works alongside category filters and pagination
- send price range values through store AJAX requests and WooCommerce product queries
- update the shortcode generator to expose price filter options and defaults

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f054f146c483308eeb85ac7db5ab41