### PR TITLE
Add configurable price filter to Norpumps store shortcode

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -9,6 +9,16 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:12px; }
+.np-price-range{ display:flex; gap:12px; align-items:flex-end; flex-wrap:wrap; }
+.np-price-range__field{ flex:1 1 120px; display:flex; flex-direction:column; gap:6px; font-weight:600; color:var(--np-text); }
+.np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
+.np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
+.np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
+.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:var(--np-accent); color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(15,91,98,0.22); }
+.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.3); background:#0d4f56; }
+.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(15,91,98,0.2); }
+.np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
@@ -30,6 +40,9 @@
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }
 .norpumps-admin .np-row label{ min-width:260px; font-weight:700; }
+.norpumps-admin .np-inline-fields{ display:flex; align-items:center; gap:10px; }
+.norpumps-admin .np-inline-fields input{ max-width:140px; padding:6px 8px; }
+.norpumps-admin .np-inline-fields .np-sep{ font-weight:700; opacity:.6; }
 .norpumps-admin .np-chip{ display:inline-flex; align-items:center; gap:6px; background:#eef7f8; padding:6px 10px; border-radius:999px; margin-right:8px; }
 .norpumps-admin .np-group{ display:flex; gap:10px; align-items:center; margin:8px 0; }
 .norpumps-admin .np-group input{ padding:6px 8px; }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,6 +9,16 @@
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }
+.np-filter--price .np-filter__body{ display:flex; flex-direction:column; gap:12px; }
+.np-price-range{ display:flex; gap:12px; align-items:flex-end; flex-wrap:wrap; }
+.np-price-range__field{ flex:1 1 120px; display:flex; flex-direction:column; gap:6px; font-weight:600; color:var(--np-text); }
+.np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
+.np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
+.np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
+.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:var(--np-accent); color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(15,91,98,0.22); }
+.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.3); background:#0d4f56; }
+.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(15,91,98,0.2); }
+.np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
 .norpumps-filters .np-checklist .depth-2{ padding-left:24px; opacity:.9 }
@@ -41,6 +51,9 @@
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }
 .norpumps-admin .np-row label{ min-width:260px; font-weight:700; }
+.norpumps-admin .np-inline-fields{ display:flex; align-items:center; gap:10px; }
+.norpumps-admin .np-inline-fields input{ max-width:140px; padding:6px 8px; }
+.norpumps-admin .np-inline-fields .np-sep{ font-weight:700; opacity:.6; }
 .norpumps-admin .np-chip{ display:inline-flex; align-items:center; gap:6px; background:#eef7f8; padding:6px 10px; border-radius:999px; margin-right:8px; }
 .norpumps-admin .np-group{ display:flex; gap:10px; align-items:center; margin:8px 0; }
 .norpumps-admin .np-group input{ padding:6px 8px; }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -7,8 +7,13 @@ $show_all  = isset($atts['show_all']) && strtolower($atts['show_all'])==='yes';
 $search_value = isset($search_query) ? $search_query : '';
 $orderby_value = isset($orderby_query) ? $orderby_query : 'menu_order title';
 if (!isset($filters_arr)) $filters_arr = [];
+$current_price_min = isset($requested_price_min) ? floatval($requested_price_min) : (isset($default_price_min) ? floatval($default_price_min) : 0);
+$current_price_max = isset($requested_price_max) ? floatval($requested_price_max) : (isset($default_price_max) ? floatval($default_price_max) : $current_price_min);
+$default_price_min_attr = isset($default_price_min) ? floatval($default_price_min) : $current_price_min;
+$default_price_max_attr = isset($default_price_max) ? floatval($default_price_max) : $current_price_max;
+$has_price_filter = in_array('price', $filters_arr, true);
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>">
+<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-min="<?php echo esc_attr(number_format($current_price_min, 2, '.', '')); ?>" data-price-max="<?php echo esc_attr(number_format($current_price_max, 2, '.', '')); ?>" data-default-price-min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" data-default-price-max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>">
   <div class="norpumps-store__header">
     <div class="norpumps-store__orderby">
       <label><?php esc_html_e('Ordenar…','norpumps'); ?></label>
@@ -27,6 +32,24 @@ if (!isset($filters_arr)) $filters_arr = [];
 
   <div class="norpumps-store__layout">
     <aside class="norpumps-filters">
+      <?php if ($has_price_filter): ?>
+        <div class="np-filter np-filter--price">
+          <div class="np-filter__head"><?php esc_html_e('Precio','norpumps'); ?></div>
+          <div class="np-filter__body">
+            <div class="np-price-range" data-default-min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" data-default-max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>">
+              <label class="np-price-range__field">
+                <span><?php esc_html_e('Mínimo','norpumps'); ?></span>
+                <input type="number" step="0.01" class="np-price-input np-price-min" min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>" value="<?php echo esc_attr(number_format($current_price_min, 2, '.', '')); ?>">
+              </label>
+              <label class="np-price-range__field">
+                <span><?php esc_html_e('Máximo','norpumps'); ?></span>
+                <input type="number" step="0.01" class="np-price-input np-price-max" min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>" value="<?php echo esc_attr(number_format($current_price_max, 2, '.', '')); ?>">
+              </label>
+            </div>
+            <button type="button" class="np-price-apply"><?php esc_html_e('Aplicar','norpumps'); ?></button>
+          </div>
+        </div>
+      <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');


### PR DESCRIPTION
## Summary
- add optional price range filter UI to the store shortcode and send it through AJAX queries
- expose min/max defaults via shortcode attributes and admin generator fields
- refresh store and admin styles to showcase the new price filter inputs and button

## Testing
- php -l modules/store/module.php

------
https://chatgpt.com/codex/tasks/task_e_68f054f146c483308eeb85ac7db5ab41