### PR TITLE
Fix price filter reload handling

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -15,9 +15,9 @@
 .np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
 .np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
 .np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
-.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:var(--np-accent); color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(15,91,98,0.22); }
-.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.3); background:#0d4f56; }
-.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(15,91,98,0.2); }
+.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:#083640; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(8,54,64,0.22); }
+.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(8,54,64,0.3); background:#0a4350; }
+.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(8,54,64,0.2); }
 .np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -150,21 +150,29 @@ jQuery(function($){
       $root.removeClass('is-loading');
     });
   }
+  function triggerReload($root, options){
+    const opts = $.extend({scroll:true, resetPage:false, normalize:false}, options);
+    if (opts.normalize){ normalizePriceRange($root); }
+    if (opts.resetPage){
+      resetToFirstPage($root);
+      load($root, 1, {scroll:opts.scroll});
+      return;
+    }
+    load($root, undefined, {scroll:opts.scroll});
+  }
   function resetToFirstPage($root){ setCurrentPage($root, 1); }
   function bindAllToggle($root){
     $root.on('change', '.np-all-toggle', function(){
       const $body = $(this).closest('.np-filter__body');
       $body.find('.np-checklist input[type=checkbox]').prop('checked', false);
-      resetToFirstPage($root);
-      load($root, 1, {scroll:true});
+      triggerReload($root, {resetPage:true, normalize:true});
     });
     $root.on('change', '.np-checklist input[type=checkbox]', function(){
       const $body = $(this).closest('.np-filter__body');
       if ($(this).is(':checked')){ $body.find('.np-all-toggle').prop('checked', false); }
       const anyChecked = $body.find('.np-checklist input:checked').length > 0;
       if (!anyChecked){ $body.find('.np-all-toggle').prop('checked', true); }
-      resetToFirstPage($root);
-      load($root, 1, {scroll:true});
+      triggerReload($root, {resetPage:true, normalize:true});
     });
   }
   function bindPriceFilter($root){
@@ -179,15 +187,11 @@ jQuery(function($){
     });
     $root.on('click', '.np-price-apply', function(e){
       e.preventDefault();
-      normalizePriceRange($root);
-      resetToFirstPage($root);
-      load($root, 1, {scroll:true});
+      triggerReload($root, {resetPage:true, normalize:true});
     });
     $root.on('blur', '.np-price-input', function(){
       if ($root.data('skipPriceBlur')){ return; }
-      normalizePriceRange($root);
-      resetToFirstPage($root);
-      load($root, 1, {scroll:true});
+      triggerReload($root, {resetPage:true, normalize:true});
     });
     $root.on('keyup', '.np-price-input', function(e){
       if (e.keyCode === 13){
@@ -202,14 +206,17 @@ jQuery(function($){
     setPerPage($root, getPerPage($root));
     setCurrentPage($root, getCurrentPage($root));
 
-    $root.on('change', '.np-orderby select', function(){ resetToFirstPage($root); load($root, 1, {scroll:true}); });
-    $root.on('keyup', '.np-search', function(e){ if (e.keyCode === 13){ resetToFirstPage($root); load($root, 1, {scroll:true}); } });
+    $root.on('change', '.np-orderby select', function(){ triggerReload($root, {resetPage:true, normalize:true}); });
+    $root.on('keyup', '.np-search', function(e){ if (e.keyCode === 13){ triggerReload($root, {resetPage:true, normalize:true}); } });
     $root.on('click', '.js-np-page', function(e){
       e.preventDefault();
       const $item = $(this).closest('.np-pagination__item');
       if ($item.hasClass('is-disabled') || $item.hasClass('is-active')) return;
       const page = parseInt($(this).data('page'), 10);
-      if (isFiniteNumber(page) && page > 0){ load($root, page, {scroll:true}); }
+      if (isFiniteNumber(page) && page > 0){
+        normalizePriceRange($root);
+        load($root, page, {scroll:true});
+      }
     });
 
     bindAllToggle($root);


### PR DESCRIPTION
## Summary
- ensure the price filter apply button shares the same reload flow as the other store controls so the updated range is always sent with AJAX queries
- normalize the price values before any filter refresh and update the apply button color to the requested #083640 tone

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f05afce6308330909a6ec7bbbc7b9a