### PR TITLE
Ensure price filter AJAX updates and styling

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -15,9 +15,9 @@
 .np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
 .np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
 .np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
-.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:var(--np-accent); color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(15,91,98,0.22); }
-.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.3); background:#0d4f56; }
-.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(15,91,98,0.2); }
+.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:#083640; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(8,54,64,0.22); }
+.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(8,54,64,0.3); background:#0a4b63; }
+.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(8,54,64,0.2); }
 .np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -15,9 +15,9 @@
 .np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
 .np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
 .np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
-.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:var(--np-accent); color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(15,91,98,0.22); }
-.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.3); background:#0d4f56; }
-.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(15,91,98,0.2); }
+.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:#083640; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(8,54,64,0.22); }
+.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(8,54,64,0.3); background:#0a4b63; }
+.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(8,54,64,0.2); }
 .np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }


### PR DESCRIPTION
## Summary
- trigger store reloads when the price range changes or is applied so the values accompany other filters in AJAX payloads
- clamp and forward the selected price range to the WooCommerce query, including a meta query to enforce the range server-side
- update the price apply button palette to use the requested #083640 tone across front-end and admin screens

## Testing
- php -l modules/store/module.php

------
https://chatgpt.com/codex/tasks/task_e_68f05afce6308330909a6ec7bbbc7b9a