### PR TITLE
Adjust store styles for price filter and responsive grid

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -15,9 +15,9 @@
 .np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
 .np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
 .np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
-.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:999px; background:#083640; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(8,54,64,0.22); }
-.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(8,54,64,0.3); background:#0a4b63; }
-.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(8,54,64,0.2); }
+.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:10px; background:#000; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(8,54,64,0.22); }
+.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(8,54,64,0.3); background:#115b6a; color:#fff; }
+.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(8,54,64,0.2); color:#fff; }
 .np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }
@@ -30,7 +30,8 @@
 .np-grid[data-columns="5"]{ grid-template-columns: repeat(5,minmax(0,1fr)); }
 .np-grid[data-columns="6"]{ grid-template-columns: repeat(6,minmax(0,1fr)); }
 .np-card{ background:#fff; border:1px solid var(--np-border); border-radius:12px; padding:12px; display:flex; flex-direction:column; }
-.np-card__image img{ width:100%; height:auto; object-fit:contain; }
+.np-card__image{ display:flex; align-items:center; justify-content:center; width:100%; height:300px; overflow:hidden; }
+.np-card__image img{ max-width:100%; max-height:100%; width:auto; height:auto; object-fit:contain; }
 .np-card__meta{ font-size:12px; color:#6a7a83; margin-top:8px; min-height:18px; }
 .np-card__title{ font-size:16px; margin:6px 0 8px; min-height:44px; }
 .np-card__price{ font-weight:700; margin-bottom:8px; }
@@ -47,6 +48,14 @@
 .np-pagination__ellipsis{ padding:6px 8px; color:#6a7a83; }
 .np-pagination__link{ display:inline-flex; align-items:center; justify-content:center; min-width:36px; min-height:36px; padding:0 10px; border-radius:999px; color:var(--np-text); border:1px solid transparent; font-weight:600; transition:all .2s ease; }
 .np-pagination__link:hover{ border-color:var(--np-accent); color:var(--np-accent); }
+
+@media(max-width: 960px){
+  .np-grid[data-columns]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
+}
+
+@media(max-width: 600px){
+  .np-grid[data-columns]{ grid-template-columns: repeat(1,minmax(0,1fr)); }
+}
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }
 .norpumps-admin .np-row{ display:flex; gap:12px; align-items:center; margin:10px 0; }


### PR DESCRIPTION
## Summary
- Restyle the price filter apply button with a black default background, teal hover state, and rounded corners.
- Normalize product card images with a fixed 300px viewport to prevent oversized thumbnails.
- Force the product grid to 2 columns on tablets and 1 column on mobile for consistent responsiveness.

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f0651ae2308330a41aef6be8f87c33