### PR TITLE
Style price filter button and hide product categories

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -15,9 +15,10 @@
 .np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
 .np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
 .np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
-.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:10px; background:#000; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(0,0,0,0.2); }
-.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(17,91,106,0.25); background:#115b6a; color:#fff; }
-.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(17,91,106,0.2); }
+.norpumps-admin .np-price-apply{ all:unset; box-sizing:border-box; align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border-radius:10px; background:#000; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(0,0,0,0.2); text-decoration:none; line-height:1; border:none; appearance:none; -webkit-appearance:none; font-family:inherit; }
+.norpumps-admin .np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(17,91,106,0.25); background:#115b6a; color:#fff; }
+.norpumps-admin .np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(17,91,106,0.2); }
+.norpumps-admin .np-price-apply:focus-visible{ outline:2px solid #115b6a; outline-offset:2px; }
 .np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -15,9 +15,10 @@
 .np-price-range__field span{ font-size:12px; letter-spacing:.02em; text-transform:uppercase; color:#5c6a70; }
 .np-price-input{ padding:10px 12px; border:1px solid var(--np-border); border-radius:10px; background:#f9fbfc; font-weight:600; color:var(--np-text); transition:border-color .2s ease, box-shadow .2s ease; }
 .np-price-input:focus{ border-color:var(--np-accent); outline:none; box-shadow:0 0 0 3px rgba(15,91,98,0.18); }
-.np-price-apply{ align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border:none; border-radius:10px; background:#000; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(0,0,0,0.2); }
-.np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(17,91,106,0.25); background:#115b6a; color:#fff; }
-.np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(17,91,106,0.2); }
+.norpumps-store .np-price-apply{ all:unset; box-sizing:border-box; align-self:flex-start; display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border-radius:10px; background:#000; color:#fff; font-weight:700; text-transform:uppercase; letter-spacing:.05em; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; box-shadow:0 10px 24px rgba(0,0,0,0.2); text-decoration:none; line-height:1; border:none; appearance:none; -webkit-appearance:none; font-family:inherit; }
+.norpumps-store .np-price-apply:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(17,91,106,0.25); background:#115b6a; color:#fff; }
+.norpumps-store .np-price-apply:active{ transform:translateY(0); box-shadow:0 6px 16px rgba(17,91,106,0.2); }
+.norpumps-store .np-price-apply:focus-visible{ outline:2px solid #115b6a; outline-offset:2px; }
 .np-filter--price .np-filter__body .np-price-range + .np-price-apply{ margin-top:4px; }
 .norpumps-filters .np-checklist label{ display:block; margin:8px 0; color:#111; }
 .norpumps-filters .np-checklist .depth-1{ padding-left:12px; opacity:.95 }

--- a/modules/store/templates/card.php
+++ b/modules/store/templates/card.php
@@ -3,9 +3,6 @@
   <a class="np-card__image" href="<?php echo esc_url(get_permalink($product->get_id())); ?>">
     <?php echo $product->get_image('woocommerce_thumbnail'); ?>
   </a>
-  <div class="np-card__meta">
-    <span class="np-card__cat"><?php echo wp_kses_post(wc_get_product_category_list($product->get_id())); ?></span>
-  </div>
   <h3 class="np-card__title"><a href="<?php echo esc_url(get_permalink($product->get_id())); ?>"><?php echo esc_html($product->get_name()); ?></a></h3>
   <div class="np-card__price"><?php echo $product->get_price_html(); ?></div>
   <div class="np-card__actions"><?php woocommerce_template_loop_add_to_cart(); ?></div>


### PR DESCRIPTION
## Summary
- restyle the price filter apply control with Norpumps-specific classes so WooCommerce defaults no longer leak through
- ensure the button stays black with white text by default, shifts to #115b6a on hover, and keeps accessibility focus styling
- remove product category metadata from product cards so the grid no longer reserves space for those labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0693187708330b16e57943f1c6c4b