### PR TITLE
Force store card price and title styling

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -42,7 +42,25 @@
 .np-card__image img{ width:100%; height:300px; object-fit:contain; }
 .np-card__meta{ font-size:12px; color:#6a7a83; margin-top:8px; min-height:18px; }
 .np-card__title{ font-size:16px; margin:6px 0 8px; min-height:44px; }
+.norpumps-store .np-card__title,
+.norpumps-store .np-card__title a{
+  font-size:16px !important;
+  color:#000 !important;
+  text-decoration:none;
+}
+.norpumps-store .np-card__title a:hover,
+.norpumps-store .np-card__title a:focus{
+  color:#286b78 !important;
+}
 .np-card__price{ font-weight:700; margin-bottom:8px; }
+.norpumps-store .np-card__price,
+.norpumps-store .np-card__price .amount,
+.norpumps-store .np-card__price ins,
+.norpumps-store .np-card__price del{
+  color:#286b78 !important;
+  font-size:20px !important;
+  line-height:1.3;
+}
 .np-card__actions .button{ background:#1f7c85; color:#fff; border:none; padding:8px 10px; border-radius:8px; }
 .np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
 .norpumps-store.is-loading .np-grid{ position:relative; opacity:.5; }


### PR DESCRIPTION
## Summary
- force the product card title link to render in black with a teal hover state while keeping typography at 16px
- ensure product prices display at 20px and use the teal brand color regardless of WooCommerce overrides

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f06e73a55c8330b6cc25d65053ea78