### PR TITLE
Limit store ordering to price selections

### DIFF
--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -1,9 +1,7 @@
 jQuery(function($){
   const ORDER_DIRECTIONS = {
     'price':'ASC',
-    'price-desc':'DESC',
-    'date':'DESC',
-    'popularity':'DESC'
+    'price-desc':'DESC'
   };
   const SCROLL_OFFSET = 120;
   const isFiniteNumber = Number.isFinite || function(value){ return typeof value === 'number' && isFinite(value); };

--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -139,7 +139,7 @@ class NorPumps_Modules_Store {
         $requested_per_page = max(1, min(60, intval(isset($_GET['per_page']) ? $_GET['per_page'] : $per_page)));
         $requested_page = max(1, intval(isset($_GET['page']) ? $_GET['page'] : $default_page));
         $search_query = sanitize_text_field(norpumps_array_get($_GET,'s',''));
-        $allowed_orderby = ['menu_order title','price','price-desc','date','popularity'];
+        $allowed_orderby = ['menu_order title','price','price-desc'];
         $orderby_query = sanitize_text_field(norpumps_array_get($_GET,'orderby','menu_order title'));
         if (!in_array($orderby_query, $allowed_orderby, true)){
             $orderby_query = 'menu_order title';
@@ -174,7 +174,7 @@ class NorPumps_Modules_Store {
             'page'=>max(1, intval(norpumps_array_get($_REQUEST,'page',1))),
             'paginate'=>true,
         ];
-        $allowed_orderby = ['menu_order title','price','price-desc','date','popularity'];
+        $allowed_orderby = ['menu_order title','price','price-desc'];
         $orderby_raw = sanitize_text_field(norpumps_array_get($_REQUEST,'orderby','menu_order title'));
         if (!in_array($orderby_raw, $allowed_orderby, true)){
             $orderby_raw = 'menu_order title';
@@ -197,6 +197,11 @@ class NorPumps_Modules_Store {
             if ($order){
                 $args['order'] = $order;
             }
+        }
+        if ($orderby === 'price' || $orderby === 'price-desc'){
+            $args['meta_key'] = '_price';
+            $args['orderby'] = 'meta_value_num';
+            $args['order'] = ($orderby === 'price-desc') ? 'DESC' : 'ASC';
         }
         $tax_query = ['relation'=>'AND'];
         foreach ($_REQUEST as $k=>$v){

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -26,8 +26,6 @@ $order_field_id = 'np-orderby-'.uniqid();
               <option value="menu_order title" <?php selected($orderby_value, 'menu_order title'); ?>><?php esc_html_e('Predeterminado','norpumps'); ?></option>
               <option value="price" <?php selected($orderby_value, 'price'); ?>><?php esc_html_e('Precio: bajo a alto','norpumps'); ?></option>
               <option value="price-desc" <?php selected($orderby_value, 'price-desc'); ?>><?php esc_html_e('Precio: alto a bajo','norpumps'); ?></option>
-              <option value="date" <?php selected($orderby_value, 'date'); ?>><?php esc_html_e('Novedades','norpumps'); ?></option>
-              <option value="popularity" <?php selected($orderby_value, 'popularity'); ?>><?php esc_html_e('Popularidad','norpumps'); ?></option>
             </select>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restrict store ordering options to the two price-based choices
- adjust server-side validation and queries to focus on price ordering
- ensure price ordering uses meta value sorting for consistent results

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0784fbd108330900d9484f4373e27