### PR TITLE
Add technical range filters to NorPumps store

### DIFF
--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -133,6 +133,14 @@ jQuery(function($){
         data['cat_'+group] = vals.join(',');
       }
     });
+    $root.find('.np-checklist[data-filter]').each(function(){
+      const filterKey = $(this).data('filter');
+      if (!filterKey){ return; }
+      const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
+      if (vals.length){
+        data[filterKey] = vals.join(',');
+      }
+    });
     return data;
   }
   function toQuery($root, obj){
@@ -250,6 +258,15 @@ jQuery(function($){
           if (values.includes(this.value)){ this.checked = true; }
         });
       }
+    });
+    $root.find('.np-checklist[data-filter]').each(function(){
+      const filterKey = $(this).data('filter');
+      if (!filterKey) return;
+      const values = (url.searchParams.get(filterKey) || '').split(',').filter(Boolean);
+      if (!values.length) return;
+      $(this).find('input').each(function(){
+        if (values.includes(this.value)){ this.checked = true; }
+      });
     });
 
     const queryOrder = url.searchParams.get('orderby');

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -12,6 +12,7 @@ $default_price_min_attr = isset($default_price_min) ? floatval($default_price_mi
 $default_price_max_attr = isset($default_price_max) ? floatval($default_price_max) : $current_price_max;
 $has_price_filter = in_array('price', $filters_arr, true);
 $has_order_filter = in_array('order', $filters_arr, true);
+$technical_filters = isset($technical_filters) && is_array($technical_filters) ? $technical_filters : [];
 $order_field_id = 'np-orderby-'.uniqid();
 ?>
 <div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-min="<?php echo esc_attr(number_format($current_price_min, 2, '.', '')); ?>" data-price-max="<?php echo esc_attr(number_format($current_price_max, 2, '.', '')); ?>" data-default-price-min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" data-default-price-max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>">
@@ -47,6 +48,20 @@ $order_field_id = 'np-orderby-'.uniqid();
             <button type="button" class="np-price-apply"><?php esc_html_e('Aplicar','norpumps'); ?></button>
           </div>
         </div>
+      <?php endif; ?>
+      <?php if (!empty($technical_filters)): ?>
+        <?php foreach ($technical_filters as $filter): ?>
+          <div class="np-filter np-filter--<?php echo esc_attr($filter['slug']); ?>">
+            <div class="np-filter__head"><?php echo esc_html($filter['label']); ?></div>
+            <div class="np-filter__body">
+              <div class="np-checklist" data-filter="<?php echo esc_attr($filter['slug']); ?>">
+                <?php foreach ($filter['bins'] as $bin): ?>
+                  <label><input type="checkbox" value="<?php echo esc_attr($bin['value']); ?>"> <?php echo esc_html($bin['label']); ?></label>
+                <?php endforeach; ?>
+              </div>
+            </div>
+          </div>
+        <?php endforeach; ?>
       <?php endif; ?>
       <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
         <?php foreach ($groups as $g):


### PR DESCRIPTION
## Summary
- extend the store shortcode with default bin settings for amperage, kilowatts, horsepower, and voltage filters and build matching WooCommerce meta queries
- render the new technical range filters alongside existing filters in the storefront template with configurable ranges from the shortcode
- enhance the frontend store script to include the technical range selections in AJAX requests, URLs, and persisted state on load

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f083ff3a9c8330b6f713419c5d7be1