### PR TITLE
Center mobile filters toggle button

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -1,10 +1,11 @@
 /* v1.2.1 — estilo similar al screenshot */
 .norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; }
 .norpumps-store a { color:#0a66a1; text-decoration:none; }
-.np-filters-toggle{ position:fixed; top:18px; right:18px; z-index:1100; display:none; align-items:center; gap:8px; padding:10px 16px; border-radius:999px; background:rgba(17,91,106,0.92); color:#fff; font-weight:700; letter-spacing:.04em; text-transform:uppercase; border:none; box-shadow:0 10px 24px rgba(15,91,98,0.35); cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; }
-.np-filters-toggle:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.45); background:#0f5b62; }
-.np-filters-toggle:focus-visible{ outline:2px solid #fff; outline-offset:2px; }
-.norpumps-store.is-filters-open .np-filters-toggle{ background:#0f5b62; }
+.np-filters-toggle{ all:unset; box-sizing:border-box; position:fixed; top:18px; left:50%; transform:translateX(-50%); z-index:1100; display:none; align-items:center; justify-content:center; gap:8px; padding:10px 18px; border-radius:999px; background:#fff; color:#286b78; font-weight:700; letter-spacing:.04em; text-transform:uppercase; border:2px solid #286b78; box-shadow:0 10px 24px rgba(40,107,120,0.18); cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease, color .2s ease; font-family:inherit; line-height:1; }
+.np-filters-toggle:hover{ transform:translate(-50%, -1px); box-shadow:0 14px 28px rgba(40,107,120,0.28); background:#286b78; color:#fff; }
+.np-filters-toggle:active{ transform:translate(-50%, 0); box-shadow:0 6px 16px rgba(40,107,120,0.22); }
+.np-filters-toggle:focus-visible{ outline:2px solid #286b78; outline-offset:3px; }
+.norpumps-store.is-filters-open .np-filters-toggle{ background:#286b78; color:#fff; }
 .np-filters-toggle__icon{ font-size:18px; line-height:1; }
 .np-filters-overlay{ position:fixed; inset:0; background:rgba(10,33,41,0.5); backdrop-filter:blur(2px); display:none; z-index:1050; }
 .norpumps-store.is-filters-open .np-filters-overlay{ display:block; }
@@ -90,6 +91,7 @@ body.np-lock-scroll{ overflow:hidden; }
 @media(max-width: 1024px){
   .norpumps-store{ padding-top:72px; }
   .np-filters-toggle{ display:inline-flex; font-size:12px; }
+  .norpumps-store.is-filters-open .np-filters-toggle{ display:none; }
   .norpumps-store__layout{ display:block; }
   .norpumps-store .norpumps-filters{ display:none; position:static; }
   .norpumps-store.is-filters-open .norpumps-filters{ display:block; position:fixed; inset:0; background:#fff; overflow-y:auto; padding:26px 20px 40px; z-index:1105; border-radius:0; max-width:none; box-shadow:0 20px 48px rgba(0,0,0,0.25); }


### PR DESCRIPTION
## Summary
- center the mobile filters toggle on smaller viewports and isolate its styling from global button rules
- ensure the toggle uses the brand color #286b78 and hides while the filters panel is visible on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f08bd416e08330b06e1a1561641425