### PR TITLE
Adjust mobile filters toggle styling

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -1,11 +1,12 @@
 /* v1.2.1 — estilo similar al screenshot */
 .norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; }
 .norpumps-store a { color:#0a66a1; text-decoration:none; }
-.np-filters-toggle{ position:fixed; top:18px; right:18px; z-index:1100; display:none; align-items:center; gap:8px; padding:10px 16px; border-radius:999px; background:rgba(17,91,106,0.92); color:#fff; font-weight:700; letter-spacing:.04em; text-transform:uppercase; border:none; box-shadow:0 10px 24px rgba(15,91,98,0.35); cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; }
-.np-filters-toggle:hover{ transform:translateY(-1px); box-shadow:0 14px 28px rgba(15,91,98,0.45); background:#0f5b62; }
-.np-filters-toggle:focus-visible{ outline:2px solid #fff; outline-offset:2px; }
-.norpumps-store.is-filters-open .np-filters-toggle{ background:#0f5b62; }
-.np-filters-toggle__icon{ font-size:18px; line-height:1; }
+.np-filters-toggle{ all:unset; box-sizing:border-box; position:fixed; top:24px; left:50%; transform:translate(-50%, 0); z-index:1100; display:none; align-items:center; justify-content:center; gap:8px; padding:10px 20px; border-radius:999px; border:2px solid #286b78; background:#fff; color:#286b78; font-weight:700; letter-spacing:.05em; text-transform:uppercase; line-height:1; box-shadow:0 10px 26px rgba(40,107,120,0.18); cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background-color .2s ease, color .2s ease; font-family:inherit; white-space:nowrap; }
+.np-filters-toggle:hover{ transform:translate(-50%, -2px); box-shadow:0 14px 32px rgba(40,107,120,0.24); background:#eef6f7; }
+.np-filters-toggle:focus-visible{ outline:3px solid rgba(40,107,120,0.45); outline-offset:4px; }
+.norpumps-store.is-filters-open .np-filters-toggle{ box-shadow:0 12px 30px rgba(40,107,120,0.22); background:#f4fafb; }
+.np-filters-toggle__icon{ font-size:18px; line-height:1; color:inherit; }
+.np-filters-toggle__label{ color:inherit; }
 .np-filters-overlay{ position:fixed; inset:0; background:rgba(10,33,41,0.5); backdrop-filter:blur(2px); display:none; z-index:1050; }
 .norpumps-store.is-filters-open .np-filters-overlay{ display:block; }
 .np-filters-close{ display:none; align-items:center; justify-content:center; border:none; background:#0f5b62; color:#fff; font-size:20px; line-height:1; width:36px; height:36px; border-radius:50%; position:absolute; top:18px; right:18px; cursor:pointer; box-shadow:0 8px 18px rgba(15,91,98,0.35); transition:transform .2s ease, box-shadow .2s ease; }
@@ -88,8 +89,8 @@ body.np-lock-scroll{ overflow:hidden; }
 .np-pagination__link{ display:inline-flex; align-items:center; justify-content:center; min-width:36px; min-height:36px; padding:0 10px; border-radius:999px; color:var(--np-text); border:1px solid transparent; font-weight:600; transition:all .2s ease; }
 .np-pagination__link:hover{ border-color:var(--np-accent); color:var(--np-accent); }
 @media(max-width: 1024px){
-  .norpumps-store{ padding-top:72px; }
-  .np-filters-toggle{ display:inline-flex; font-size:12px; }
+  .norpumps-store{ padding-top:82px; }
+  .np-filters-toggle{ display:inline-flex; font-size:13px; padding:12px 28px; }
   .norpumps-store__layout{ display:block; }
   .norpumps-store .norpumps-filters{ display:none; position:static; }
   .norpumps-store.is-filters-open .norpumps-filters{ display:block; position:fixed; inset:0; background:#fff; overflow-y:auto; padding:26px 20px 40px; z-index:1105; border-radius:0; max-width:none; box-shadow:0 20px 48px rgba(0,0,0,0.25); }
@@ -98,6 +99,9 @@ body.np-lock-scroll{ overflow:hidden; }
   .norpumps-store.is-filters-open .np-filters-close{ position:sticky; top:0; margin-left:auto; margin-right:0; }
   .norpumps-store.is-filters-open .norpumps-filters .np-filter__head{ border-radius:14px 14px 0 0; }
   .norpumps-store.is-filters-open .norpumps-filters .np-filter__body{ border-radius:0 0 14px 14px; }
+}
+@media(max-width: 600px){
+  .np-filters-toggle{ font-size:12px; padding:11px 24px; }
 }
 /* Admin pretty */
 .norpumps-admin .np-card{ background:#fff; border:1px solid #e7eef2; border-radius:12px; padding:14px; }


### PR DESCRIPTION
## Summary
- center the filters toggle button on mobile/tablet and isolate its styling so the label always uses the required #286b78 color
- update responsive spacing so the toggle replaces the hidden filters drawer on small screens without overlapping the header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f08bd416e08330b06e1a1561641425