### PR TITLE
Add mobile-friendly filter modal

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -2,7 +2,88 @@
 .norpumps-store { --np-accent:#0f5b62; --np-bg:#fff; --np-text:#111; --np-border:#e3e9ee; }
 .norpumps-store a { color:#0a66a1; text-decoration:none; }
 .norpumps-store__layout { display:grid; grid-template-columns: 300px 1fr; gap:24px; }
+body.np-filters-modal-open { overflow:hidden; }
+.np-filters-trigger{ display:none; border:none; background:#0f5b62; color:#fff; font-weight:700; letter-spacing:.05em; text-transform:uppercase; padding:12px 20px; border-radius:999px; box-shadow:0 12px 30px rgba(15,91,98,0.28); align-items:center; gap:10px; cursor:pointer; transition:transform .2s ease, box-shadow .2s ease, background .2s ease; font-size:14px; }
+.np-filters-trigger__icon{ font-size:18px; line-height:1; }
+.np-filters-trigger:focus-visible{ outline:2px solid #fff; outline-offset:3px; }
+.np-filters-trigger:hover{ box-shadow:0 16px 34px rgba(15,91,98,0.35); background:#0d4c52; }
+.np-filters-trigger:active{ box-shadow:0 10px 24px rgba(15,91,98,0.28); }
+.np-filters-backdrop{ display:none; }
+.np-filters-close{ display:none; }
 @media(max-width: 960px){ .norpumps-store__layout{ grid-template-columns:1fr; } }
+.norpumps-store.has-mobile-filters .np-filters-trigger{ display:none; }
+@media(max-width: 1024px){
+  .norpumps-store.has-mobile-filters{ position:relative; padding-top:72px; }
+  .norpumps-store.has-mobile-filters .np-filters-trigger{
+    display:inline-flex;
+    position:fixed;
+    top:18px;
+    left:50%;
+    transform:translateX(-50%);
+    max-width:220px;
+    justify-content:center;
+    z-index:1200;
+  }
+  .norpumps-store.has-mobile-filters .np-filters-trigger:hover{
+    transform:translate(-50%, -1px);
+  }
+  .norpumps-store.has-mobile-filters .np-filters-trigger:active{
+    transform:translate(-50%, 0);
+  }
+  .norpumps-store.has-mobile-filters .np-filters-backdrop{
+    display:none;
+    position:fixed;
+    inset:0;
+    background:rgba(9,31,35,0.55);
+    z-index:1100;
+  }
+  .norpumps-store.has-mobile-filters.np-filters-open .np-filters-backdrop{ display:block; }
+  .norpumps-store.has-mobile-filters .norpumps-filters{
+    display:none;
+  }
+  .norpumps-store.has-mobile-filters.np-filters-open .norpumps-filters{
+    display:block;
+    position:fixed;
+    top:90px;
+    left:50%;
+    transform:translateX(-50%);
+    width:min(92vw, 420px);
+    max-height:calc(100vh - 140px);
+    overflow-y:auto;
+    background:#f6fafb;
+    padding:18px 18px 24px;
+    border-radius:18px;
+    box-shadow:0 18px 45px rgba(9,31,35,0.35);
+    z-index:1300;
+  }
+  .norpumps-store.has-mobile-filters .np-filters-close{
+    display:inline-flex;
+    margin-left:auto;
+    margin-bottom:12px;
+    border:none;
+    background:#0f5b62;
+    color:#fff;
+    width:34px;
+    height:34px;
+    border-radius:50%;
+    align-items:center;
+    justify-content:center;
+    font-size:16px;
+    font-weight:700;
+    cursor:pointer;
+    box-shadow:0 10px 24px rgba(15,91,98,0.3);
+  }
+  .norpumps-store.has-mobile-filters .np-filters-close:focus-visible{
+    outline:2px solid #fff;
+    outline-offset:3px;
+  }
+  .norpumps-store.has-mobile-filters .np-filters-close:hover{
+    background:#0d4c52;
+  }
+  .norpumps-store.has-mobile-filters .np-filters-close:active{
+    box-shadow:0 6px 16px rgba(15,91,98,0.25);
+  }
+}
 .norpumps-filters .np-filter{ margin-bottom:18px; }
 .norpumps-filters .np-filter__head{ background:var(--np-accent); color:#fff; padding:12px 14px; font-weight:800; letter-spacing:.02em; text-transform:uppercase; border-radius:10px 10px 0 0; }
 .norpumps-filters .np-filter__body{ background:#fff; border:1px solid var(--np-border); border-top:none; padding:12px 14px; border-radius:0 0 10px 10px; }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -12,11 +12,30 @@ $default_price_min_attr = isset($default_price_min) ? floatval($default_price_mi
 $default_price_max_attr = isset($default_price_max) ? floatval($default_price_max) : $current_price_max;
 $has_price_filter = in_array('price', $filters_arr, true);
 $has_order_filter = in_array('order', $filters_arr, true);
+$has_cat_filter = in_array('cat', $filters_arr, true) && !empty($groups);
+$has_any_filter = $has_price_filter || $has_order_filter || $has_cat_filter;
+$filters_element_id = 'np-filters-'.uniqid();
 $order_field_id = 'np-orderby-'.uniqid();
 ?>
-<div class="norpumps-store" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-min="<?php echo esc_attr(number_format($current_price_min, 2, '.', '')); ?>" data-price-max="<?php echo esc_attr(number_format($current_price_max, 2, '.', '')); ?>" data-default-price-min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" data-default-price-max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>">
+<?php
+$store_classes = ['norpumps-store'];
+if ($has_any_filter) {
+    $store_classes[] = 'has-mobile-filters';
+}
+?>
+<div class="<?php echo esc_attr(implode(' ', $store_classes)); ?>" data-columns="<?php echo esc_attr($columns); ?>" data-per-page="<?php echo esc_attr($current_per_page); ?>" data-default-per-page="<?php echo esc_attr($per_page); ?>" data-current-page="<?php echo esc_attr($current_page); ?>" data-default-page="<?php echo esc_attr($default_page_attr); ?>" data-price-min="<?php echo esc_attr(number_format($current_price_min, 2, '.', '')); ?>" data-price-max="<?php echo esc_attr(number_format($current_price_max, 2, '.', '')); ?>" data-default-price-min="<?php echo esc_attr(number_format($default_price_min_attr, 2, '.', '')); ?>" data-default-price-max="<?php echo esc_attr(number_format($default_price_max_attr, 2, '.', '')); ?>">
+  <?php if ($has_any_filter): ?>
+    <button type="button" class="np-filters-trigger" aria-controls="<?php echo esc_attr($filters_element_id); ?>" aria-expanded="false">
+      <span class="np-filters-trigger__icon" aria-hidden="true">✨</span>
+      <span class="np-filters-trigger__label"><?php esc_html_e('Filtros','norpumps'); ?></span>
+    </button>
+    <div class="np-filters-backdrop" aria-hidden="true"></div>
+  <?php endif; ?>
   <div class="norpumps-store__layout">
-    <aside class="norpumps-filters">
+    <aside id="<?php echo esc_attr($filters_element_id); ?>" class="norpumps-filters" aria-live="polite">
+      <?php if ($has_any_filter): ?>
+        <button type="button" class="np-filters-close" aria-label="<?php esc_attr_e('Cerrar filtros','norpumps'); ?>">✕</button>
+      <?php endif; ?>
       <?php if ($has_order_filter): ?>
         <div class="np-filter np-filter--order">
           <div class="np-filter__head"><?php esc_html_e('Ordenar','norpumps'); ?></div>
@@ -48,7 +67,7 @@ $order_field_id = 'np-orderby-'.uniqid();
           </div>
         </div>
       <?php endif; ?>
-      <?php if (in_array('cat',$filters_arr) && !empty($groups)): ?>
+      <?php if ($has_cat_filter): ?>
         <?php foreach ($groups as $g):
           $parent = get_term_by('slug', $g['slug'], 'product_cat');
           if (!$parent) continue; ?>


### PR DESCRIPTION
## Summary
- add a floating mobile-only filters trigger and backdrop in the store template so the existing filters render inside a modal
- style the trigger, backdrop, and filter panel for small screens while keeping the desktop experience unchanged
- extend the store javascript to manage opening/closing the modal and automatically hide it after ajax updates

## Testing
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f08faeeb148330a30074d6bb1403bd