### PR TITLE
Hide mobile filter close button on desktop

### DIFF
--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -221,7 +221,16 @@ jQuery(function($){
         openFilters();
       }
     }
+    function syncCloseButton(){
+      if (!$closeBtn.length){ return; }
+      if (isMobile()){
+        $closeBtn.removeAttr('hidden');
+      } else {
+        $closeBtn.attr('hidden', 'hidden');
+      }
+    }
     function handleMediaChange(){
+      syncCloseButton();
       if (!isMobile()){
         closeFilters();
       }

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -34,7 +34,7 @@ if ($has_any_filter) {
   <div class="norpumps-store__layout">
     <aside id="<?php echo esc_attr($filters_element_id); ?>" class="norpumps-filters" aria-live="polite">
       <?php if ($has_any_filter): ?>
-        <button type="button" class="np-filters-close" aria-label="<?php esc_attr_e('Cerrar filtros','norpumps'); ?>">✕</button>
+        <button type="button" class="np-filters-close" aria-label="<?php esc_attr_e('Cerrar filtros','norpumps'); ?>" hidden>✕</button>
       <?php endif; ?>
       <?php if ($has_order_filter): ?>
         <div class="np-filter np-filter--order">


### PR DESCRIPTION
## Summary
- keep the mobile filters close button hidden by default in the markup
- toggle the close button's visibility in JavaScript so it only appears on mobile viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0927f5f8c83309be3007eafde950a