### PR TITLE
Ensure mobile filter close button only shows on touch breakpoints

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,7 +9,7 @@ body.np-filters-modal-open { overflow:hidden; }
 .np-filters-trigger:hover{ box-shadow:0 16px 34px rgba(15,91,98,0.35); background:#0d4c52; }
 .np-filters-trigger:active{ box-shadow:0 10px 24px rgba(15,91,98,0.28); }
 .np-filters-backdrop{ display:none; }
-.np-filters-close{ display:none; }
+.np-filters-close{ display:none !important; }
 @media(max-width: 960px){ .norpumps-store__layout{ grid-template-columns:1fr; } }
 .norpumps-store.has-mobile-filters .np-filters-trigger{ display:none; }
 @media(max-width: 1024px){
@@ -56,7 +56,7 @@ body.np-filters-modal-open { overflow:hidden; }
     box-shadow:0 18px 45px rgba(9,31,35,0.35);
     z-index:1300;
   }
-  .norpumps-store.has-mobile-filters .np-filters-close{
+  .norpumps-store.has-mobile-filters.np-show-mobile-close .np-filters-close{
     display:inline-flex;
     margin-left:auto;
     margin-bottom:12px;
@@ -73,14 +73,14 @@ body.np-filters-modal-open { overflow:hidden; }
     cursor:pointer;
     box-shadow:0 10px 24px rgba(15,91,98,0.3);
   }
-  .norpumps-store.has-mobile-filters .np-filters-close:focus-visible{
+  .norpumps-store.has-mobile-filters.np-show-mobile-close .np-filters-close:focus-visible{
     outline:2px solid #fff;
     outline-offset:3px;
   }
-  .norpumps-store.has-mobile-filters .np-filters-close:hover{
+  .norpumps-store.has-mobile-filters.np-show-mobile-close .np-filters-close:hover{
     background:#0d4c52;
   }
-  .norpumps-store.has-mobile-filters .np-filters-close:active{
+  .norpumps-store.has-mobile-filters.np-show-mobile-close .np-filters-close:active{
     box-shadow:0 6px 16px rgba(15,91,98,0.25);
   }
 }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -189,6 +189,7 @@ jQuery(function($){
     const $backdrop = $root.find('.np-filters-backdrop');
     if (!$trigger.length || !$filters.length){ return; }
     const $closeBtn = $filters.find('.np-filters-close');
+    const mobileCloseClass = 'np-show-mobile-close';
     const instanceId = Math.random().toString(36).slice(2);
     const mediaQuery = window.matchMedia ? window.matchMedia('(max-width: 1024px)') : null;
     function isMobile(){
@@ -222,10 +223,15 @@ jQuery(function($){
       }
     }
     function syncCloseButton(){
-      if (!$closeBtn.length){ return; }
+      if (!$closeBtn.length){
+        $root.removeClass(mobileCloseClass);
+        return;
+      }
       if (isMobile()){
+        $root.addClass(mobileCloseClass);
         $closeBtn.removeAttr('hidden');
       } else {
+        $root.removeClass(mobileCloseClass);
         $closeBtn.attr('hidden', 'hidden');
       }
     }


### PR DESCRIPTION
## Summary
- hide the filter close button by default and only reveal it on mobile breakpoints
- toggle a dedicated class from JavaScript so the close button appears exclusively when the layout is in its modal/mobile state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f095b1556083309215d26b36d34df1