### PR TITLE
Restore mobile filter close button

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,7 +9,7 @@ body.np-filters-modal-open { overflow:hidden; }
 .np-filters-trigger:hover{ box-shadow:0 16px 34px rgba(15,91,98,0.35); background:#0d4c52; }
 .np-filters-trigger:active{ box-shadow:0 10px 24px rgba(15,91,98,0.28); }
 .np-filters-backdrop{ display:none; }
-.np-filters-close{ display:none !important; }
+.np-filters-close{ display:none; }
 @media(max-width: 960px){ .norpumps-store__layout{ grid-template-columns:1fr; } }
 .norpumps-store.has-mobile-filters .np-filters-trigger{ display:none; }
 @media(max-width: 1024px){


### PR DESCRIPTION
## Summary
- allow the mobile filters close button to be displayed again by relaxing the global hide rule so the mobile styles can apply

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f0984a44748330858126776d00751f