### PR TITLE
Restore filter close button on mobile view

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -9,7 +9,10 @@ body.np-filters-modal-open { overflow:hidden; }
 .np-filters-trigger:hover{ box-shadow:0 16px 34px rgba(15,91,98,0.35); background:#0d4c52; }
 .np-filters-trigger:active{ box-shadow:0 10px 24px rgba(15,91,98,0.28); }
 .np-filters-backdrop{ display:none; }
-.np-filters-close{ display:none !important; }
+.np-filters-close{ display:none; }
+@media(min-width: 1025px){
+  .np-filters-close{ display:none !important; }
+}
 @media(max-width: 960px){ .norpumps-store__layout{ grid-template-columns:1fr; } }
 .norpumps-store.has-mobile-filters .np-filters-trigger{ display:none; }
 @media(max-width: 1024px){


### PR DESCRIPTION
## Summary
- allow the filters close button to display again on mobile and tablet layouts
- keep the close button hidden for desktop by scoping the hide rule to wide viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f09a35b5d4833085bf0b24335233ca