### PR TITLE
Add extensible metadata filters to store module

### DIFF
--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -133,6 +133,19 @@ jQuery(function($){
         data['cat_'+group] = vals.join(',');
       }
     });
+    $root.find('.np-checklist[data-meta-key]').each(function(){
+      const metaKey = $(this).data('metaKey');
+      if (!metaKey){ return; }
+      const vals = $(this).find('input:checked').map(function(){ return this.value; }).get();
+      const allOn = $(this).closest('.np-filter__body').find('.np-all-toggle').is(':checked');
+      if (vals.length && !allOn){
+        data['meta_filters['+metaKey+']'] = vals.join(',');
+        const metaType = $(this).data('metaType');
+        if (metaType){
+          data['meta_types['+metaKey+']'] = metaType;
+        }
+      }
+    });
     return data;
   }
   function toQuery($root, obj){
@@ -142,6 +155,7 @@ jQuery(function($){
     Object.keys(obj).forEach(key => {
       if (['action','nonce'].includes(key)) return;
       if (obj[key] === '' || obj[key] == null) return;
+      if (key.indexOf('meta_types[') === 0) return;
       if (key === 'page' && parseInt(obj[key], 10) === defaultPage) return;
       if (key === 'per_page' && parseInt(obj[key], 10) === defaultPer) return;
       params.set(key, obj[key]);
@@ -342,6 +356,19 @@ jQuery(function($){
       if (!group) return;
       const key = 'cat_'+group;
       const values = (url.searchParams.get(key) || '').split(',').filter(Boolean);
+      if (values.length){
+        const $body = $(this).closest('.np-filter__body');
+        $body.find('.np-all-toggle').prop('checked', false);
+        $(this).find('input').each(function(){
+          if (values.includes(this.value)){ this.checked = true; }
+        });
+      }
+    });
+    $root.find('.np-checklist[data-meta-key]').each(function(){
+      const metaKey = $(this).data('metaKey');
+      if (!metaKey) return;
+      const queryKey = 'meta_filters['+metaKey+']';
+      const values = (url.searchParams.get(queryKey) || '').split(',').filter(Boolean);
       if (values.length){
         const $body = $(this).closest('.np-filter__body');
         $body.find('.np-all-toggle').prop('checked', false);

--- a/modules/store/templates/store.php
+++ b/modules/store/templates/store.php
@@ -13,7 +13,8 @@ $default_price_max_attr = isset($default_price_max) ? floatval($default_price_ma
 $has_price_filter = in_array('price', $filters_arr, true);
 $has_order_filter = in_array('order', $filters_arr, true);
 $has_cat_filter = in_array('cat', $filters_arr, true) && !empty($groups);
-$has_any_filter = $has_price_filter || $has_order_filter || $has_cat_filter;
+$has_meta_filters = !empty($meta_filters);
+$has_any_filter = $has_price_filter || $has_order_filter || $has_cat_filter || $has_meta_filters;
 $filters_element_id = 'np-filters-'.uniqid();
 $order_field_id = 'np-orderby-'.uniqid();
 ?>
@@ -91,6 +92,21 @@ if ($has_any_filter) {
                 }
                 np_render_children_only($parent->term_id,0);
                 ?>
+              </div>
+            </div>
+          </div>
+        <?php endforeach; ?>
+      <?php endif; ?>
+      <?php if ($has_meta_filters): ?>
+        <?php foreach ($meta_filters as $meta): ?>
+          <div class="np-filter np-filter--meta" data-meta-key="<?php echo esc_attr($meta['key']); ?>">
+            <div class="np-filter__head"><?php echo esc_html(strtoupper($meta['label'])); ?></div>
+            <div class="np-filter__body">
+              <label class="np-all"><input type="checkbox" class="np-all-toggle" checked> <?php esc_html_e('Todos','norpumps'); ?></label>
+              <div class="np-checklist" data-meta-key="<?php echo esc_attr($meta['key']); ?>" data-meta-type="<?php echo esc_attr($meta['type']); ?>">
+                <?php foreach ($meta['options'] as $option): ?>
+                  <label><input type="checkbox" value="<?php echo esc_attr($option['value']); ?>"> <?php echo esc_html($option['label']); ?></label>
+                <?php endforeach; ?>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- parse dynamic meta filter attributes from the norpumps_store shortcode and expose them to the frontend
- render range-based metadata filters with checkbox bins alongside the existing store filters
- update AJAX query building to honor selected metadata ranges while keeping default behaviour unchanged

## Testing
- php -l modules/store/module.php
- php -l modules/store/templates/store.php

------
https://chatgpt.com/codex/tasks/task_e_68f115a8d3b48330b8cc06746ed0846f