### PR TITLE
Preserve meta filter shortcode attributes

### DIFF
--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -119,6 +119,7 @@ class NorPumps_Modules_Store {
         wp_send_json_success($out);
     }
     public function shortcode_store($atts){
+        $raw_atts = is_array($atts) ? $atts : [];
         $atts = shortcode_atts([
             'columns'=>4,
             'filters'=>'cat',
@@ -128,6 +129,14 @@ class NorPumps_Modules_Store {
             'price_min'=>0,
             'price_max'=>10000,
         ], $atts, 'norpumps_store');
+        foreach ($raw_atts as $name => $value){
+            if (!is_string($name)){
+                continue;
+            }
+            if (preg_match('/^meta\d+_/i', $name)){
+                $atts[$name] = $value;
+            }
+        }
         $columns = max(2, min(6, intval($atts['columns'])));
         $per_page = max(1, min(60, intval($atts['per_page'])));
         $groups = [];


### PR DESCRIPTION
## Summary
- keep custom meta filter attributes when processing the norpumps_store shortcode so they remain available for rendering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f12c0ee5e883309550b72c5f3e1afe