### PR TITLE
Add empty state UI when store filters return no products

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -150,6 +150,16 @@ body.np-filters-modal-open { overflow:hidden; }
 .np-card__actions .ajax_add_to_cart.added::after{ content:"\2713"; margin-left:.5rem; font-weight:700; display:inline-block; transform:translateY(-1px); }
 .norpumps-store.is-loading .np-grid{ position:relative; opacity:.5; }
 .norpumps-store.is-loading .np-grid::after{ content:'Cargando…'; position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-weight:600; font-size:14px; color:#0f5b62; background:rgba(255,255,255,0.65); border-radius:12px; }
+.norpumps-store .np-empty-state{ display:flex; flex-direction:column; align-items:center; justify-content:center; gap:16px; text-align:center; padding:48px 24px; border-radius:18px; background:linear-gradient(135deg, rgba(17,91,98,0.08), rgba(17,91,98,0.02)); color:#0f5b62; box-shadow:0 20px 45px rgba(17,91,98,0.12); margin:36px auto; max-width:540px; width:100%; }
+.norpumps-store .np-empty-state__icon{ font-size:44px; line-height:1; display:inline-flex; align-items:center; justify-content:center; width:72px; height:72px; border-radius:50%; background:rgba(255,255,255,0.85); box-shadow:0 12px 24px rgba(17,91,98,0.15); }
+.norpumps-store .np-empty-state__title{ margin:0; font-size:24px; font-weight:700; color:#0d3940; }
+.norpumps-store .np-empty-state__description{ margin:0; font-size:16px; line-height:1.6; color:#284c53; max-width:420px; }
+@media(max-width: 600px){
+  .norpumps-store .np-empty-state{ padding:32px 18px; margin:28px auto; gap:14px; }
+  .norpumps-store .np-empty-state__icon{ width:64px; height:64px; font-size:38px; }
+  .norpumps-store .np-empty-state__title{ font-size:21px; }
+  .norpumps-store .np-empty-state__description{ font-size:15px; }
+}
 .np-pagination{ margin:24px 0 0; text-align:center; }
 .np-pagination__nav{ display:inline-block; background:#fff; border:1px solid var(--np-border); border-radius:999px; padding:6px 10px; box-shadow:0 6px 16px rgba(15,91,98,0.08); }
 .np-pagination__list{ list-style:none; display:flex; align-items:center; gap:4px; margin:0; padding:0; }

--- a/modules/store/module.php
+++ b/modules/store/module.php
@@ -381,14 +381,30 @@ class NorPumps_Modules_Store {
             include __DIR__.'/templates/card.php';
         }
         wp_reset_postdata();
+        $html = ob_get_clean();
+        if (trim($html) === ''){
+            $html = $this->render_empty_state_html();
+        }
         wp_send_json_success([
-            'html'=>ob_get_clean(),
+            'html'=>$html,
             'pagination_html'=>$this->render_pagination_html(max(1, intval($args['page'] ?? 1)), max(1, $max_pages)),
             'total'=>$total,
             'page'=>max(1, intval($args['page'] ?? 1)),
             'max_pages'=>max(1, $max_pages),
             'args'=>$args,
         ]);
+    }
+    private function render_empty_state_html(){
+        $title = esc_html__('No encontramos resultados', 'norpumps');
+        $message = esc_html__('Ajusta los filtros o limpia la búsqueda para intentarlo de nuevo.', 'norpumps');
+        $icon_label = esc_html__('Sin resultados', 'norpumps');
+        $html  = '<div class="np-empty-state" role="status" aria-live="polite">';
+        $html .= '<span class="np-empty-state__icon" aria-hidden="true" role="img">🔎</span>';
+        $html .= '<span class="screen-reader-text">'.$icon_label.'</span>';
+        $html .= '<h3 class="np-empty-state__title">'.$title.'</h3>';
+        $html .= '<p class="np-empty-state__description">'.$message.'</p>';
+        $html .= '</div>';
+        return $html;
     }
     private function render_pagination_html($current_page, $total_pages){
         if ($total_pages <= 1){


### PR DESCRIPTION
## Summary
- add an empty state message when store filter queries return zero products
- style the empty state so it looks friendly and adapts to small screens

## Testing
- php -l modules/store/module.php

------
https://chatgpt.com/codex/tasks/task_e_68f143e415e48330996e7ae5fe220514