### PR TITLE
Adjust empty state message layout on desktop

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -154,6 +154,10 @@ body.np-filters-modal-open { overflow:hidden; }
 .norpumps-store .np-empty-state__icon{ font-size:44px; line-height:1; display:inline-flex; align-items:center; justify-content:center; width:72px; height:72px; border-radius:50%; background:rgba(255,255,255,0.85); box-shadow:0 12px 24px rgba(17,91,98,0.15); }
 .norpumps-store .np-empty-state__title{ margin:0; font-size:24px; font-weight:700; color:#0d3940; }
 .norpumps-store .np-empty-state__description{ margin:0; font-size:16px; line-height:1.6; color:#284c53; max-width:420px; }
+@media(min-width: 1025px){
+  .norpumps-store .np-empty-state{ max-width:none; margin:36px 0; }
+  .norpumps-store .np-empty-state__description{ max-width:min(840px, 100%); }
+}
 @media(max-width: 600px){
   .norpumps-store .np-empty-state{ padding:32px 18px; margin:28px auto; gap:14px; }
   .norpumps-store .np-empty-state__icon{ width:64px; height:64px; font-size:38px; }


### PR DESCRIPTION
## Summary
- remove the desktop width constraint from the empty state message so it can span the available product area
- allow the description text to expand on wide screens while keeping the mobile styling intact

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f1492238a883308aa800c2ee891076