### PR TITLE
Adjust empty state layout to span full width

### DIFF
--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -116,6 +116,8 @@ body.np-filters-modal-open { overflow:hidden; }
 .np-grid[data-columns="5"]{ grid-template-columns: repeat(5,minmax(0,1fr)); }
 .np-grid[data-columns="6"]{ grid-template-columns: repeat(6,minmax(0,1fr)); }
 .np-grid[data-columns]{ transition:grid-template-columns .2s ease; }
+.np-grid.np-grid--empty{ display:flex; flex-direction:column; align-items:center; width:100%; }
+.np-grid.np-grid--empty .np-empty-state{ max-width:100%; width:100%; }
 @media(max-width: 960px){
   .np-grid[data-columns]{ grid-template-columns: repeat(2,minmax(0,1fr)); }
 }

--- a/assets/js/store.js
+++ b/assets/js/store.js
@@ -186,7 +186,12 @@ jQuery(function($){
     closeMobileFilters($root);
     $.post(NorpumpsStore.ajax_url, payload, function(resp){
       if (!resp || !resp.success) return;
-      $root.find('.js-np-grid').html(resp.data.html);
+      const $grid = $root.find('.js-np-grid');
+      $grid.html(resp.data.html);
+      const totalItems = Number(resp.data.total);
+      const isEmpty = isFiniteNumber(totalItems) ? totalItems < 1 : $.trim(resp.data.html || '') === '';
+      $grid.toggleClass('np-grid--empty', isEmpty);
+      $root.toggleClass('norpumps-store--empty', isEmpty);
       $root.find('.js-np-pagination').html(resp.data.pagination_html || '');
       if (resp.data.page){ setCurrentPage($root, resp.data.page); }
       if (resp.data.args && resp.data.args.limit){ setPerPage($root, resp.data.args.limit); }


### PR DESCRIPTION
## Summary
- update the store grid logic to flag when the empty state is shown so the layout can expand
- add styles that make the empty results message occupy the full product area and remain centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f14c63a58c8330ab0fef6cb24da049